### PR TITLE
fix(vault-scribe): prohibit incompatible TOC directives, document correct approach

### DIFF
--- a/skills/vault-scribe/SKILL.md
+++ b/skills/vault-scribe/SKILL.md
@@ -107,7 +107,15 @@ mkdir -p ~/.claude/skills/my-skill
 
 For directory trees, use plain `text` or no language tag.
 
-### 6. Tables & Links
+### 6. Table of Contents
+
+**Never use `[TOC]`, `[[_TOC_]]`, or any other TOC directive** — neither GitHub nor Obsidian supports them natively. They render as broken plain text.
+
+- GitHub auto-generates a TOC in the sidebar — no directive needed.
+- Obsidian generates one via its built-in plugin — no directive needed.
+- Only add a **manual** TOC (using standard anchor links) when the document has 6+ sections and will be read outside a browser. See `references/MARKDOWN-SYNTAX.md` for anchor rules and an example.
+
+### 7. Tables & Links
 
 Use Markdown tables for comparisons, option lists, and reference links. Always include a reference links table at the end:
 
@@ -118,7 +126,7 @@ Use Markdown tables for comparisons, option lists, and reference links. Always i
 | Source Video  | [youtube.com/watch?v=...](https://youtube.com/watch?v=...) |
 ```
 
-### 7. Inline Formatting Rules
+### 8. Inline Formatting Rules
 
 | Element | Usage |
 |---|---|
@@ -127,7 +135,7 @@ Use Markdown tables for comparisons, option lists, and reference links. Always i
 | `` `code` `` | All file paths, commands, config keys, code symbols |
 | `[[wikilink]]` | Internal Obsidian links (only if Obsidian-only context) |
 
-### 8. Transcript Appendix
+### 9. Transcript Appendix
 
 When the source material includes a transcript (video, podcast, meeting recording, article), **always** append the raw transcript at the very end of the document, after all other content, using this exact format:
 

--- a/skills/vault-scribe/references/MARKDOWN-SYNTAX.md
+++ b/skills/vault-scribe/references/MARKDOWN-SYNTAX.md
@@ -131,6 +131,41 @@ Inline footnote.^[This is inline.]    <!-- Inline style: Obsidian only -->
 
 ---
 
+## Table of Contents
+
+Neither GitHub nor Obsidian supports inline TOC directives natively. **Never use `[TOC]`, `[[_TOC_]]`, or any other TOC directive** — they render as broken text or plain blockquotes on both platforms.
+
+| Syntax | GitHub | Obsidian | Notes |
+|---|---|---|---|
+| `[TOC]` | ❌ | ❌ | Renders as plain text |
+| `[[_TOC_]]` | ❌ | ❌ | Azure DevOps only |
+| `<!-- TOC -->` | ❌ | ❌ | No processor on either platform |
+| Manual anchor links | ✅ | ✅ | **Use this** |
+| Auto sidebar TOC | ✅ | ✅ (plugin) | Generated automatically — no directive needed |
+
+**When a TOC is needed**, write it manually using standard Markdown anchor links:
+
+```markdown
+## Table of Contents
+
+- [Overview](#overview)
+- [How It Works](#how-it-works)
+  - [Step One](#step-one)
+- [Examples](#examples)
+- [References](#references)
+```
+
+Heading anchor rules (same on GitHub and Obsidian):
+- Lowercase all characters
+- Replace spaces with hyphens `-`
+- Remove all punctuation except hyphens
+- Example: `## How It Works` → `#how-it-works`
+
+> [!NOTE]
+> GitHub automatically renders a clickable TOC in the document sidebar — no inline TOC is needed for `.md` files viewed on GitHub. Only add a manual TOC when the document is long (6+ sections) and will be read outside a browser context.
+
+---
+
 ## Compatibility Quick Reference
 
 | Feature | GFM (GitHub) | Obsidian |
@@ -151,3 +186,5 @@ Inline footnote.^[This is inline.]    <!-- Inline style: Obsidian only -->
 | Math (LaTeX) | ✅ | ✅ |
 | Task lists | ✅ | ✅ |
 | Footnotes `[^1]` | ✅ | ✅ |
+| `[TOC]` / `[[_TOC_]]` directives | ❌ | ❌ |
+| Manual anchor-link TOC | ✅ | ✅ |


### PR DESCRIPTION
## Summary

Closes #1

- `MARKDOWN-SYNTAX.md` — new `## Table of Contents` section documenting all broken TOC directives (`[TOC]`, `[[_TOC_]]`, `<!-- TOC -->`), anchor slug rules, and a correct manual anchor-link TOC example; two new rows added to the compatibility matrix
- `SKILL.md` — new `### 6. Table of Contents` step in the document creation workflow explicitly banning TOC directives and defining when a manual TOC is appropriate

## Test plan

- [x] Invoke `/vault-scribe article` with long source material and verify no `[TOC]` or `[[_TOC_]]` directive appears in the output
- [x] Verify any generated TOC uses manual anchor links (`[Section](#section)`)
- [x] Confirm `MARKDOWN-SYNTAX.md` compatibility matrix includes TOC rows