### PR TITLE
feat: add design-critique skill for structured design and plan stress-testing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,6 +15,12 @@
       "source": "./skills/git-commit-pr-message",
       "description": "Generate Conventional Commits messages, PR descriptions, Keep a Changelog entries, and release workflows with sensitive content scanning",
       "version": "1.0.0"
+    },
+    {
+      "name": "design-critique",
+      "source": "./skills/design-critique",
+      "description": "Structured design critique and plan stress-testing. Acts as a relentless interviewer drawing on pre-mortem, red teaming, and ATAM techniques to help someone think through a design or plan exhaustively. Use when the user says \"grill me\", \"critique this\", \"stress-test this\", \"pre-mortem\", \"red team this\", or asks to be challenged on a technical architecture, product plan, feature design, or any decision rather than validated.",
+      "version": "1.0.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Think of it as a playbook: you define the process once, and the agent follows it
 | **[vault-scribe](skills/vault-scribe/)** | `/vault-scribe` | Converts transcripts, meeting notes, brainstorming sessions, strategy docs, and rough notes into polished Obsidian vault Markdown — GitHub-compatible by default, with type-aware frontmatter schemas |
 | **[agentic-skeleton-dir-structure](skills/agentic-skeleton-dir-structure/)** | `/agentic-skeleton-dir-structure` | Scaffolds production-ready directory structures for agentic AI projects using Agent-OS v3 (Builder Methods) — supports single repos, mono-repos, multi-language repos, any platform, any language |
 | **[git-commit-pr-message](skills/git-commit-pr-message/)** | `/git-commit-pr-message` | Generates Conventional Commits messages, PR titles/descriptions, and Keep a Changelog v1.1.0 entries — with sensitive content scanning, GitHub/Jira ticket linking, and release workflow |
+| **[design-critique](skills/design-critique/)** | `/design-critique` | Structured design critique and plan stress-testing — acts as a relentless interviewer using pre-mortem, red teaming, and ATAM techniques to challenge technical architectures, product plans, and feature designs exhaustively |
 
 ### vault-scribe
 
@@ -136,6 +137,36 @@ git-commit-pr-message/
 ├── SKILL.md                          Workflow (9 steps) + behavioural rules
 └── references/
     └── examples.md                   Commit, PR, changelog, ticket, and scan examples
+```
+
+### design-critique
+
+Your design review sparring partner. Stress-tests technical architectures, product plans, and feature designs using structured interviewing techniques drawn from pre-mortem analysis, red teaming, and ATAM (Architecture Tradeoff Analysis Method).
+
+**What it does:**
+
+1. **Orients silently** — explores the codebase or relevant files before asking anything
+2. **Anchors the session** — establishes scope with a single opening question
+3. **Drills relentlessly** — one question at a time, following the highest-risk thread first
+4. **Surfaces hidden assumptions** — names what's unstated and forces trade-off articulation
+5. **Closes with a summary** — what held up, what didn't, and what needs resolution before proceeding
+
+**Question patterns it uses:**
+
+| Pattern | Purpose |
+|---|---|
+| What happens when X fails? | Failure modes |
+| What does the alternative look like? | Trade-off articulation |
+| How would you know if this is wrong? | Falsifiability |
+| What's the cost of reversing this? | Reversibility |
+| Walk me through the worst case | Pre-mortem |
+| What quality attribute does this sacrifice? | ATAM tradeoff probe |
+
+**Skills 2.0:** `allowed-tools: Read Grep Glob` — `argument-hint: [topic, file, or artifact to critique]` — auto-invokes on trigger phrases; no external tools required
+
+```
+design-critique/
+└── SKILL.md                          Interviewing principles, question patterns, session flow
 ```
 
 ---

--- a/skills/design-critique/SKILL.md
+++ b/skills/design-critique/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: design-critique
+description: >
+  Structured design critique and plan stress-testing. Acts as a relentless interviewer
+  drawing on pre-mortem, red teaming, and ATAM techniques to help someone think through
+  a design or plan exhaustively. Use when the user says "grill me", "critique this",
+  "stress-test this", "pre-mortem", "red team this", or asks to be challenged on a
+  technical architecture, product plan, feature design, or any decision rather than
+  validated.
+allowed-tools: Read Grep Glob
+argument-hint: "[topic, file, or artifact to critique]"
+compatibility: No external tools required. File access is optional — enhances context when available.
+---
+
+# Design Critique
+
+A structured interviewing technique rooted in pre-mortem analysis, red teaming, and
+ATAM (Architecture Tradeoff Analysis Method). The goal is exhaustive challenge, not
+validation.
+
+## Quick start
+
+```
+User:  "Grill me on this auth design."
+Agent: "What are you trying to decide or build, and what's the single biggest
+        risk you see in it?"
+User:  "We're using JWTs with a 30-day expiry and no revocation mechanism."
+Agent: "What happens when a token is stolen? Walk me through the worst case."
+```
+
+1. If file access is available, explore the codebase or relevant files silently first
+2. Ask one opening question to anchor the session: *"What are you trying to decide
+   or build, and what's the single biggest risk you see in it?"*
+3. Then interrogate relentlessly — one question at a time
+
+## Workflows
+
+**Session flow:**
+
+1. **Orient** — Understand the artifact (codebase, doc, plan) before asking
+2. **Anchor** — Establish scope: what's being stress-tested and why now
+3. **Drill** — Follow the highest-risk thread first, then branch
+4. **Surface gaps** — Name assumptions, missing pieces, unresolved dependencies
+5. **Close** — Summarize what held up, what didn't, and what needs resolution
+
+**Interviewing principles:**
+
+- **One question at a time.** Never bundle questions. Each answer earns the next.
+- **Dig before moving on.** Follow threads until resolved or exhausted. Don't accept vague answers.
+- **Challenge, don't validate.** Find holes, not affirmations. Be direct.
+- **Name assumptions explicitly.** "That assumes X — is that true?"
+- **Track open threads.** Park issues and return: "We'll come back to X."
+
+**Question patterns:**
+
+- **What happens when X fails?** (failure modes)
+- **Who else is affected by this decision?** (dependencies / stakeholders)
+- **What does the alternative look like?** (force trade-off articulation)
+- **How would you know if this is wrong?** (falsifiability)
+- **What's the cost of reversing this?** (reversibility)
+- **What are you not saying?** (surface omissions)
+- **Walk me through the worst case.** (pessimistic path — pre-mortem)
+- **What would have to be true for this to fail completely?** (preconditions)
+- **What quality attribute does this sacrifice?** (ATAM tradeoff probe)
+
+## Tone
+
+Direct, skeptical, intellectually rigorous. Not hostile — a good sparring partner,
+not an adversary. Push back on weak reasoning. Acknowledge strong answers and move on.


### PR DESCRIPTION
## Summary

- Adds `design-critique` skill — a structured interviewing agent rooted in pre-mortem analysis, red teaming, and ATAM techniques
- Registers skill in `.claude-plugin/marketplace.json`
- Documents skill in `README.md` with table entry and detail section

## Details

The skill acts as a relentless sparring partner, challenging technical architectures, product plans, and feature designs one question at a time. It triggers on phrases like `"grill me"`, `"critique this"`, `"stress-test"`, `"pre-mortem"`, and `"red team this"`.

Closes #3

## Test plan

- [x] Trigger skill with `"grill me on this design"` — confirm opening anchor question fires
- [x] Trigger skill with `"stress-test this"` — confirm session flow starts correctly
- [x] Confirm skill appears in marketplace listing