### PR TITLE
feat(vault-scribe): add how-to and technical note types with governance fields

### DIFF
--- a/skills/vault-scribe/SKILL.md
+++ b/skills/vault-scribe/SKILL.md
@@ -9,7 +9,7 @@ description: >
   or requests for GitHub-compatible Markdown documents.
 user-invocable: true
 allowed-tools: Read, Grep, Edit, Write
-argument-hint: "[note-type: article|meeting|brainstorming|strategy|deep-research]"
+argument-hint: "[note-type: article|how-to|technical|meeting|brainstorming|strategy|deep-research]"
 ---
 
 # Vault Scribe — Obsidian + GitHub Markdown Skill
@@ -40,6 +40,8 @@ When invoked with an argument (e.g. `/vault-scribe meeting`), use `$ARGUMENTS` t
 | If the user wants… | Set `type` to |
 |---|---|
 | A guide, reference doc, or knowledge article | `article` |
+| A step-by-step instructional guide or procedure | `how-to` |
+| Architecture docs, RFCs, design docs, system specs | `technical` |
 | An investigation with multiple sources | `deep-research` |
 | A versioned plan or strategy document | `strategy` |
 | Meeting notes, 1:1s, standups, retrospectives | `meeting` |

--- a/skills/vault-scribe/examples/how-to-example.md
+++ b/skills/vault-scribe/examples/how-to-example.md
@@ -1,0 +1,128 @@
+---
+type: how-to
+title: "How to Configure a GitHub Actions CI Pipeline"
+author: "Philip A Senger"
+category: "How-To"
+tags:
+  - how-to
+  - github-actions
+  - ci-cd
+  - devops
+description: "Step-by-step guide to setting up a GitHub Actions workflow for CI on a Node.js project"
+summary: >
+  Walks through creating a GitHub Actions workflow file, configuring Node.js
+  matrix testing, and adding a status badge to the project README.
+status: published
+version: "1.0.0"
+date_created: 2026-03-14
+date_updated: 2026-03-14
+prerequisites:
+  - "GitHub repository with a Node.js project"
+  - "package.json with a `test` script defined"
+reviewers:
+  - "Alice Johnson"
+next_review_date: 2026-09-14
+revision_notes:
+  - "1.0.0 - Initial publication"
+---
+
+# How to Configure a GitHub Actions CI Pipeline
+
+This guide sets up a GitHub Actions workflow that runs tests on every push and pull request.
+
+## Prerequisites
+
+Before you begin:
+
+- A GitHub repository with a Node.js project
+- `package.json` with a `test` script (e.g. `jest`, `mocha`, `vitest`)
+- Write access to the repository
+
+## Steps
+
+### 1. Create the Workflow Directory
+
+```bash
+mkdir -p .github/workflows
+```
+
+### 2. Create the Workflow File
+
+Create `.github/workflows/ci.yml`:
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+
+      - run: npm ci
+      - run: npm test
+```
+
+### 3. Commit and Push
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add GitHub Actions CI workflow"
+git push
+```
+
+### 4. Verify the Workflow Ran
+
+Navigate to **Actions** tab in your GitHub repository. You should see the workflow trigger within seconds of the push.
+
+### 5. Add a Status Badge (Optional)
+
+Add to your `README.md`:
+
+```markdown
+![CI](https://github.com/<owner>/<repo>/actions/workflows/ci.yml/badge.svg)
+```
+
+Replace `<owner>` and `<repo>` with your GitHub username and repository name.
+
+> [!TIP]
+> Use `npm ci` instead of `npm install` in CI — it installs exactly what is in `package-lock.json` and fails if the lock file is out of sync.
+
+> [!WARNING]
+> Do not cache `node_modules` directly. Use `cache: "npm"` on the `setup-node` action — it caches the npm cache directory, which is safer and more portable across Node versions.
+
+## Troubleshooting
+
+| Problem | Likely Cause | Fix |
+|---|---|---|
+| Workflow does not trigger | Branch name mismatch | Confirm `branches` list matches your default branch |
+| `npm ci` fails | Missing or outdated `package-lock.json` | Run `npm install` locally and commit the lock file |
+| Tests pass locally but fail in CI | Environment variable missing | Add secrets via **Settings → Secrets and variables → Actions** |
+
+## Further Reading & References
+
+| Resource | Link |
+|---|---|
+| GitHub Actions Docs | [docs.github.com/actions](https://docs.github.com/en/actions) |
+| `setup-node` Action | [github.com/actions/setup-node](https://github.com/actions/setup-node) |
+| Workflow syntax reference | [docs.github.com/actions/writing-workflows](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions) |
+
+> [!abstract] TL;DR
+> Create `.github/workflows/ci.yml`, define an `on: push / pull_request` trigger, use `actions/setup-node` with a Node version matrix, then run `npm ci && npm test`. Push and verify in the Actions tab.

--- a/skills/vault-scribe/examples/technical-example.md
+++ b/skills/vault-scribe/examples/technical-example.md
@@ -1,0 +1,147 @@
+---
+type: technical
+title: "Event Bus Architecture"
+author: "Philip A Senger"
+category: "Software Architecture"
+tags:
+  - event-bus
+  - architecture
+  - messaging
+  - distributed-systems
+  - pub-sub
+description: "Design specification for the internal event bus used across platform services"
+summary: >
+  Documents the publish/subscribe architecture of the internal event bus,
+  including topic conventions, consumer group patterns, and failure handling.
+  Covers both the synchronous and asynchronous delivery paths.
+status: published
+version: "1.1.0"
+date_created: 2026-01-20
+date_updated: 2026-03-14
+system: "Platform Core"
+component: "Event Bus"
+reviewers:
+  - "Alice Johnson"
+  - "Bob Chen"
+next_reviewer:
+  - "Carol Williams"
+next_review_date: 2026-07-01
+signoff:
+  - name: "Alice Johnson"
+    date: "2026-01-25"
+  - name: "Bob Chen"
+    date: "2026-01-26"
+revision_notes:
+  - "1.0.0 - Initial architecture specification"
+  - "1.1.0 - Added dead-letter queue pattern and retry policy"
+related: "[[platform-core-overview]]"
+---
+
+# Event Bus Architecture
+
+The event bus is the internal pub/sub backbone used by all platform services. Producers publish typed events to named topics; consumers subscribe via consumer groups and process events independently.
+
+## Overview
+
+| Concept | Description |
+|---|---|
+| **Topic** | Named channel scoped to a domain, e.g. `orders.created` |
+| **Producer** | Any service that emits events to a topic |
+| **Consumer Group** | A set of service instances sharing a subscription cursor |
+| **Dead-Letter Queue (DLQ)** | Receives events that fail processing after all retries |
+
+## How It Works
+
+```
+Producer → Topic → [Consumer Group A]
+                 → [Consumer Group B]
+                 → [DLQ] (on repeated failure)
+```
+
+Each consumer group maintains its own cursor. Multiple groups can consume the same topic independently without interfering.
+
+### Topic Naming Convention
+
+```
+<domain>.<entity>.<event>
+
+orders.payment.captured
+users.account.created
+inventory.item.reserved
+```
+
+- All lowercase, dot-separated
+- Domain first, then entity, then past-tense verb
+
+## Delivery Guarantees
+
+| Mode | Guarantee | When to use |
+|---|---|---|
+| `at-least-once` | Default. Events may be delivered more than once | Most use cases |
+| `exactly-once` | Requires idempotent consumers + transactional producers | Financial events |
+
+> [!IMPORTANT]
+> Consumers **must** be idempotent. Duplicate delivery is possible under failure scenarios even in `at-least-once` mode.
+
+## Retry and Failure Handling
+
+```yaml
+retry_policy:
+  max_attempts: 5
+  backoff: exponential
+  initial_delay: 500ms
+  max_delay: 30s
+```
+
+After `max_attempts`, the event is routed to the DLQ for the topic:
+
+```
+orders.payment.captured  →  dlq.orders.payment.captured
+```
+
+> [!WARNING]
+> Monitor DLQ depth in your service dashboard. Unprocessed DLQ events indicate a persistent consumer failure that will not self-heal.
+
+## Practical Example
+
+**Publishing an event (Node.js):**
+
+```typescript
+await eventBus.publish("orders.payment.captured", {
+  orderId: "ord_abc123",
+  amount: 4999,
+  currency: "USD",
+  capturedAt: new Date().toISOString(),
+});
+```
+
+**Consuming events:**
+
+```typescript
+eventBus.subscribe("orders.payment.captured", "fulfilment-service", async (event) => {
+  await fulfilmentQueue.enqueue(event.payload.orderId);
+});
+```
+
+## Schema Versioning
+
+All event payloads are versioned. Breaking schema changes require a new topic name:
+
+```
+orders.payment.captured.v1   →  deprecated
+orders.payment.captured.v2   →  current
+```
+
+> [!CAUTION]
+> Never modify the schema of an active topic in a breaking way. Old consumers will silently fail to deserialise the payload.
+
+## Further Reading & References
+
+| Resource | Link |
+|---|---|
+| Platform Core Overview | `[[platform-core-overview]]` |
+| Dead-Letter Queue Runbook | `[[dlq-runbook]]` |
+| CloudEvents Spec | [cloudevents.io](https://cloudevents.io) |
+
+> [!abstract] TL;DR
+> The event bus uses named topics with consumer groups. Producers publish typed, versioned events. Consumers must be idempotent. Failed events go to per-topic DLQs after exponential backoff retries. Topic names follow `<domain>.<entity>.<past-tense-verb>` convention.

--- a/skills/vault-scribe/references/FRONT-MATTER.md
+++ b/skills/vault-scribe/references/FRONT-MATTER.md
@@ -9,13 +9,13 @@ Properties use YAML frontmatter at the start of a note. The `type` field is the 
 ## Property Types
 
 | Type | Example |
-|------|---------|
+|---|---|
 | Text | `title: "My Title"` |
 | Enum | `status: published` |
 | Date | `date_created: 2026-03-14` |
-| List | `tags: [one, two]` or YAML list |
-| List of Strings | `attendees:` followed by `- "Full Name"` items |
-| Links | `related: "[[Other Note]]"` |
+| List of strings | `tags: [one, two]` or YAML block list |
+| List of objects | `signoff:` followed by `- name:` / `date:` pairs |
+| Wikilink | `related: "[[Other Note]]"` |
 | Semver | `version: "1.0.0"` |
 | URL | `source: "https://example.com"` |
 
@@ -23,11 +23,13 @@ Properties use YAML frontmatter at the start of a note. The `type` field is the 
 
 ## Note Types
 
-| `type` value | Purpose | Extra required fields |
+| `type` | Purpose | Extra required fields |
 |---|---|---|
 | `article` | Knowledge base articles, guides, reference docs | *(core only)* |
-| `deep-research` | In-depth investigation with sources | `sources` |
-| `strategy` | Living strategy/planning docs with versions | `version`, `related` |
+| `how-to` | Step-by-step instructional guides and procedures | *(core only)* |
+| `technical` | In-depth technical documentation: architecture, RFCs, design docs, system specs | `system`, `component` |
+| `deep-research` | In-depth investigation with cited sources | `sources` |
+| `strategy` | Living strategy/planning docs | `version`, `related`, `prepared_for`, `quarter` |
 | `meeting` | Meeting notes, 1:1s, standups, retrospectives | `attendees`, `meeting_date` |
 | `brainstorming` | Ideation, exploratory thinking, solo or group | *(core only)* |
 
@@ -48,23 +50,25 @@ description: "One sentence — what is this document about"
 summary: >
   Two to three sentences — what does the reader learn.
 status: published
+version: "1.0.0"
 date_created: 2026-03-14
 date_updated: 2026-03-14
 ---
 ```
 
-### Field Rules
+### Core Field Rules
 
 | Field | Type | Rules |
 |---|---|---|
-| `type` | enum | Required. See note types above |
+| `type` | enum | Required. See note types table above |
 | `title` | text | Title Case. Must match the H1 heading |
 | `author` | text | Full name. Default: `"Philip A Senger"` |
-| `category` | enum | Exactly ONE value from the category list below |
-| `tags` | list | 4-12 lowercase-hyphenated slugs |
+| `category` | enum | Exactly one value from the category list below |
+| `tags` | list of strings | 4–12 lowercase-hyphenated slugs |
 | `description` | text | One sentence. Plain text, no Markdown |
-| `summary` | text | 2-3 sentences. Use YAML multiline `>` |
+| `summary` | text | 2–3 sentences. Use YAML multiline `>` |
 | `status` | enum | `published`, `draft`, or `in-progress` |
+| `version` | semver | `"X.Y.Z"`. Increment on meaningful revisions |
 | `date_created` | date | `YYYY-MM-DD`. Set once at creation |
 | `date_updated` | date | `YYYY-MM-DD`. Update on every edit |
 
@@ -94,12 +98,16 @@ Use exactly one (Title Case):
 - Documentation
 - Education
 - Entrepreneurship
+- Finance
+- How-To
 - Leadership
+- Legal & Compliance
 - Marketing
 - Mental Health
 - Methodology
 - Mobile Development
 - Monitoring
+- Operations
 - Personal Development
 - Product Management
 - Productivity
@@ -112,6 +120,47 @@ Use exactly one (Title Case):
 - Web Development
 
 > When none fit, pick the closest match. Do not invent new categories without the user's approval.
+
+---
+
+## Review & Governance Fields (any note type)
+
+These fields track the review lifecycle and sign-off history of a document. All are optional unless the note type specifies otherwise.
+
+| Field | Type | Description |
+|---|---|---|
+| `reviewers` | list of strings | Full names of everyone who reviews this document |
+| `next_reviewer` | list of strings | Full names of who should review next |
+| `next_review_date` | date | `YYYY-MM-DD` — scheduled date for the next review |
+| `signoff` | list of objects | Sign-off records. Each entry: `name: "Full Name"`, `date: "YYYY-MM-DD"` |
+| `revision_notes` | list of strings | Change log entries. Each prefixed with version: `"1.1.0 - Updated security section"` |
+| `published` | list of objects | Publication records. Each entry: `when: "YYYY-MM-DD"`, `where: "https://..."`, `version: "1.0.0"` |
+| `backup` | string | Optional. Filename of a backup archive, e.g. `"archive-v1.0.0.zip"` |
+
+**Example:**
+
+```yaml
+reviewers:
+  - "Alice Johnson"
+  - "Bob Chen"
+next_reviewer:
+  - "Carol Williams"
+next_review_date: 2026-06-01
+signoff:
+  - name: "Alice Johnson"
+    date: "2026-03-15"
+  - name: "Bob Chen"
+    date: "2026-03-16"
+revision_notes:
+  - "1.0.0 - Initial publication"
+  - "1.1.0 - Added deployment checklist"
+  - "1.2.0 - Revised security section based on audit"
+published:
+  - when: "2026-03-15"
+    where: "https://internal.example.com/docs/guide"
+    version: "1.0.0"
+backup: "archive-v1.1.0.zip"
+```
 
 ---
 
@@ -136,6 +185,7 @@ summary: >
   Explains what Claude Skills are, how they are discovered and loaded,
   and how to write effective skill descriptions.
 status: published
+version: "1.0.0"
 date_created: 2026-03-04
 date_updated: 2026-03-04
 ---
@@ -153,9 +203,102 @@ date_updated: 2026-03-04
 
 ---
 
+### `how-to`
+
+Step-by-step instructional guides and procedures. Focused on a specific task outcome. Core fields only.
+
+```yaml
+---
+type: how-to
+title: "How to Set Up a Pre-Commit Hook with Husky"
+author: "Philip A Senger"
+category: "How-To"
+tags:
+  - how-to
+  - husky
+  - pre-commit
+  - git
+description: "Step-by-step guide to configuring Husky pre-commit hooks in a Node.js project"
+summary: >
+  Walks through installing Husky, configuring lint-staged,
+  and wiring up formatting and type-check scripts to run on every commit.
+status: published
+version: "1.0.0"
+date_created: 2026-03-14
+date_updated: 2026-03-14
+---
+```
+
+**Optional fields:**
+
+| Field | Type | When to use |
+|---|---|---|
+| `prerequisites` | list of strings | Tools or knowledge required before following the guide |
+| `aliases` | list of strings | Alternative names for the procedure |
+| `read_time` | text | Estimated time to complete, e.g. `"15 min"` |
+| `source` | URL | When based on an official source or doc |
+
+---
+
+### `technical`
+
+In-depth technical documentation for systems, components, APIs, and architecture. Use for RFCs, design docs, architecture decision records (ADRs), and internal system specifications.
+
+```yaml
+---
+type: technical
+title: "Authentication Service Architecture"
+author: "Philip A Senger"
+category: "Software Architecture"
+tags:
+  - authentication
+  - architecture
+  - jwt
+  - security
+description: "Architecture and design specification for the authentication service"
+summary: >
+  Documents the design, component breakdown, and data flow of the authentication
+  service, including token lifecycle and failure handling.
+status: published
+version: "1.2.0"
+date_created: 2026-01-10
+date_updated: 2026-03-14
+system: "Identity Platform"
+component: "Authentication Service"
+reviewers:
+  - "Alice Johnson"
+  - "Bob Chen"
+next_review_date: 2026-06-01
+signoff:
+  - name: "Alice Johnson"
+    date: "2026-03-15"
+revision_notes:
+  - "1.0.0 - Initial design doc"
+  - "1.1.0 - Added token refresh flow"
+  - "1.2.0 - Revised failure handling after incident review"
+---
+```
+
+**Required additional fields:**
+
+| Field | Type | Rules |
+|---|---|---|
+| `system` | text | The broader system or platform this document belongs to |
+| `component` | text | The specific component, service, or subsystem being documented |
+
+**Optional additional fields:**
+
+| Field | Type | When to use |
+|---|---|---|
+| `sources` | list of links | RFCs, papers, or external specs referenced |
+| `related` | wikilink or list | Links to companion ADRs, runbooks, or design docs |
+| `aliases` | list of strings | Alternative names (e.g. abbreviated service name) |
+
+---
+
 ### `deep-research`
 
-In-depth investigations, literature reviews, or research notes with sources.
+In-depth investigations, literature reviews, or research notes with cited sources.
 
 ```yaml
 ---
@@ -172,6 +315,7 @@ summary: >
   Reviews five major agent orchestration frameworks, comparing their
   architecture, scalability, and developer experience.
 status: draft
+version: "1.0.0"
 date_created: 2026-03-10
 date_updated: 2026-03-12
 sources:
@@ -216,7 +360,21 @@ status: published
 version: "2.0.0"
 date_created: 2025-12-01
 date_updated: 2026-02-15
+prepared_for: "Leadership Team"
+quarter: "Q1 2026"
 related: "[[north-star-workbook-2026]]"
+reviewers:
+  - "Alice Johnson"
+  - "Bob Chen"
+next_reviewer:
+  - "Carol Williams"
+next_review_date: 2026-04-01
+signoff:
+  - name: "Alice Johnson"
+    date: "2026-01-10"
+revision_notes:
+  - "1.0.0 - Initial draft"
+  - "2.0.0 - Full rewrite for 2026 planning cycle"
 ---
 ```
 
@@ -224,25 +382,24 @@ related: "[[north-star-workbook-2026]]"
 
 | Field | Type | Rules |
 |---|---|---|
-| `version` | semver | `"X.Y.Z"` format. Increment on meaningful revisions |
-| `related` | wikilink or list | Obsidian `"[[wikilink]]"` to companion docs |
+| `version` | semver | `"X.Y.Z"`. Increment on every meaningful revision |
+| `related` | wikilink or list | `"[[wikilink]]"` to companion docs |
+| `prepared_for` | text | Name or role of intended audience, e.g. `"Leadership Team"`, `"Engineering All-Hands"` |
+| `quarter` | text | Fiscal or calendar quarter covered, e.g. `"Q2 2026"` |
 
 **Optional additional fields:**
 
 | Field | Type | When to use |
 |---|---|---|
-| `backup` | text | Filename of backup archive, e.g. `"Archive-v1.0.0.zip"` |
+| `backup` | string | Filename of backup archive, e.g. `"archive-v1.0.0.zip"` |
 | `date_revised` | date | Formal revision date if different from `date_updated` |
-| `next_review` | text | Who and when for the next review |
-| `reviewers` | list of strings | People who review this document |
-| `revision_notes` | text | Use multiline `>` for notes about what changed |
-| `tracking` | text | External tracking system reference, e.g. `"Jira (Epics & Stories)"` |
+| `tracking` | text | External tracking reference, e.g. `"Jira (Epics & Stories)"` |
 
 ---
 
 ### `meeting`
 
-Meeting notes, 1:1s, standups, retrospectives, and any note tied to a specific calendar event or collaborative session.
+Meeting notes, 1:1s, standups, retrospectives, and notes tied to a specific calendar event.
 
 ```yaml
 ---
@@ -259,6 +416,7 @@ summary: >
   Covers what went well, what did not, and action items
   from the Sprint 12 retrospective.
 status: published
+version: "1.0.0"
 date_created: 2026-03-14
 date_updated: 2026-03-14
 meeting_date: 2026-03-14
@@ -288,7 +446,7 @@ attendees:
 
 ### `brainstorming`
 
-Ideation and exploratory thinking — solo with AI, one-on-one, or group sessions. Use for iterating on ideas, evaluating options, or converging on a decision. Core fields only; all additional fields are optional to support both solo and group contexts.
+Ideation and exploratory thinking — solo with AI, one-on-one, or group sessions. Core fields only; all additional fields are optional to support both solo and group contexts.
 
 ```yaml
 ---
@@ -305,6 +463,7 @@ summary: >
   Evaluated REST, GraphQL, and gRPC. Converged on a hybrid
   REST + GraphQL strategy based on client needs.
 status: published
+version: "1.0.0"
 date_created: 2026-03-14
 date_updated: 2026-03-14
 ---
@@ -316,7 +475,7 @@ date_updated: 2026-03-14
 |---|---|---|
 | `attendees` | list of strings | When brainstorming in a group or meeting setting |
 | `meeting_date` | date | When tied to a specific session date |
-| `sources` | list of links | When the brainstorm draws on external references or research |
+| `sources` | list of links | When the brainstorm draws on external references |
 | `action_items` | list of strings | Decisions or next steps from the session |
 
 **Group brainstorming example:**
@@ -336,6 +495,7 @@ summary: >
   Ranked 12 feature proposals using weighted scoring.
   Top 3 selected for Q3 development.
 status: published
+version: "1.0.0"
 date_created: 2026-03-14
 date_updated: 2026-03-14
 meeting_date: 2026-03-14
@@ -364,7 +524,7 @@ tags:
 - Lowercase and hyphenated only: `software-development`, not `Software Development`
 - Topic-specific tags first, broader domain tags after
 - Include at least one technology tag and one domain tag
-- 4-12 tags per note
+- 4–12 tags per note
 - No `#` prefix in frontmatter
 
 Tags can contain: letters (any language), numbers (not first character), underscores `_`, hyphens `-`, forward slashes `/` (for nesting).
@@ -377,7 +537,7 @@ Tags can contain: letters (any language), numbers (not first character), undersc
 | Domain | `software-development`, `project-management`, `devops` |
 | Concept | `design-patterns`, `architecture`, `testing`, `security` |
 | Methodology | `agile`, `lean-startup`, `spec-driven` |
-| Content type | `deep-research`, `meeting-notes`, `retrospective`, `brainstorming` |
+| Content type | `deep-research`, `meeting-notes`, `retrospective`, `brainstorming`, `how-to` |
 
 ---
 
@@ -399,12 +559,10 @@ aliases:
 
 ## Optional Fields (any note type)
 
-These fields can appear on any note type when relevant:
-
 | Field | Type | When to use |
 |---|---|---|
-| `aliases` | list of strings | 3-5 alternative names for Obsidian search and linking |
+| `aliases` | list of strings | 3–5 alternative names for Obsidian search and linking |
 | `subtitle` | text | Secondary title or tagline |
 | `read_time` | text | Estimated reading time, e.g. `"10 min"` |
 | `source` | URL | Single external source reference |
-| `sources` | list of links | Multiple source references as `"[Label](URL)"` |
+| `sources` | list of links | Multiple sources as `"[Label](URL)"` |


### PR DESCRIPTION
## Summary

- Add two new note types: `how-to` (step-by-step instructional guides) and `technical` (architecture docs, RFCs, ADRs, system specs)
- Promote `version` to a core field required on all note types
- Introduce a reusable Review & Governance block (`reviewers`, `next_reviewer`, `next_review_date`, `signoff`, `revision_notes`, `published`, `backup`) available on any note type

## Ticket

Closes #10

## Changes

**`SKILL.md`**
- Added `how-to` and `technical` to the argument hint

**`references/FRONT-MATTER.md`**
- Full schemas for `how-to` and `technical` note types
- `version` added to core fields and all type-specific examples
- New Review & Governance section with field definitions and a worked example
- `strategy` type expanded with `prepared_for` and `quarter` required fields; governance fields added to its example
- New categories: Finance, How-To, Legal & Compliance, Operations
- Property type labels updated: "List of strings", "List of objects", "Wikilink"
- Minor copy/formatting fixes (en-dashes, table alignment)

**`examples/`**
- `how-to-example.md` — GitHub Actions CI pipeline setup guide
- `technical-example.md` — Internal event bus architecture spec

## Test Plan

- [ ] Invoke `/vault-scribe how-to` and confirm the skill produces a valid `how-to` note with correct front matter
- [ ] Invoke `/vault-scribe technical` and confirm `system` and `component` fields are included
- [ ] Verify `version` appears in the front matter of notes generated for all existing types (article, meeting, brainstorming, strategy, deep-research)
- [ ] Confirm governance fields (reviewers, signoff, etc.) can be added to any note type without validation errors in Obsidian

## Changelog

- Added `how-to` and `technical` note types to vault-scribe ([#10](https://github.com/psenger/ai-agent-skills/issues/10))