### PR TITLE
feat(handoff): add handoff skill for structured session context transfer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,6 +33,12 @@
       "source": "./skills/create-a-skill",
       "description": "Create new agent skills from scratch, modify and improve existing skills, and measure skill performance through evaluation and benchmarking. Use when users want to create a skill, write a skill, build a new skill, edit or optimize an existing skill, run evals to test a skill, benchmark skill performance, or optimize a skill's description for better triggering accuracy. Also triggers when users say \"turn this into a skill\", \"make a skill for X\", \"skill for doing Y\", or ask about skill structure, skill format, or SKILL.md files.",
       "version": "1.0.0"
+    },
+    {
+      "name": "handoff",
+      "source": "./skills/handoff",
+      "description": "Make sure to use this skill whenever the user types /handoff (with or without a filename argument), says \"handoff\", \"save state\", \"context rot\", \"save session\", \"create a handoff\", \"I need a clean start\", wants to snapshot progress before clearing context or switching sessions, is approaching the context limit (300–400k tokens), or wants to delegate the current session state to another agent. Also invoke for RESUME mode: when the user says \"load handoff\", \"resume from [file]\", \"continue where we left off\", \"pick up where I left off\", \"load the handoff at [path]\", references a .claude/handoffs/ file path, or says there is a handoff file from a prior session.",
+      "version": "1.0.0"
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.swp
 *~
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **handoff** — New skill that saves or loads a structured JSON snapshot of session state (schema v2.0.0) so work can resume cleanly in a new session or be handed to a sub-agent. Supports CREATE (default timestamped path or explicit filename) and RESUME (load most-recent or named file) workflows. Proactively suggests a handoff after 5+ file edits or a major decision. ([#14](https://github.com/psenger/ai-agent-skills/issues/14))
+
 ## [1.0.0] - 2026-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Think of it as a playbook: you define the process once, and the agent follows it
 | **[arch-lens](skills/arch-lens/)** | `/arch-lens` | Seven-step interactive architectural review anchored in Ousterhout's deep-module principle — explores a codebase for shallow modules, hidden coupling, and testability seams, spawns parallel sub-agents to design competing interfaces, then writes a structured RFC action file readable by GitHub MCP or ROVO (Jira) MCP |
 | **[review-api-design](skills/review-api-design/)** | `/review-api-design` | Reviews REST API designs during the planning phase against security, resilience, design, and operational best practices — produces structured findings with severity levels, source citations, and a readiness assessment |
 | **[create-a-skill](skills/create-a-skill/)** | `/create-a-skill` | Create new agent skills from scratch, modify and improve existing skills, and measure skill performance — interviews the user, drafts SKILL.md with bundled resources, runs evals, benchmarks, iterates on feedback, optimises description triggering, and packages distributable `.skill` files |
+| **[handoff](skills/handoff/)** | `/handoff` | Saves or loads a structured JSON snapshot of session state so work can resume cleanly in a new session or be delegated to a sub-agent — better than `/compact` because the schema forces every field to be explicit |
 
 ### vault-scribe
 
@@ -512,6 +513,25 @@ Or trigger it naturally:
 ```
 
 The skill interviews you about requirements before writing anything. It handles the full lifecycle — from initial draft through eval, iteration, description optimisation, and packaging.
+
+### handoff
+
+Captures the complete state of your current session to a structured JSON snapshot so you can resume cleanly in a new session, switch task phases, or delegate work to a sub-agent without losing context.
+
+**Two modes:**
+
+| Mode | When to use |
+|---|---|
+| CREATE | Session approaching 300–400k tokens, switching phases, delegating to a sub-agent, or starting fresh with correct state |
+| RESUME | Loading a prior snapshot to continue where you left off |
+
+**Why it beats `/compact`:** Compaction is lossy and exhibits recency bias. The schema forces every field — goal, decisions, completed steps, pending steps, constraints, discovered issues, modified files — to be explicit. Nothing is silently dropped.
+
+```
+/handoff                          # save to .claude/handoffs/<timestamp>-<slug>.json
+/handoff auth-refactor.json       # save to explicit path
+/handoff load auth-refactor.json  # resume from file
+```
 
 ---
 

--- a/skills/handoff/.skillignore
+++ b/skills/handoff/.skillignore
@@ -1,0 +1,1 @@
+.workspace/

--- a/skills/handoff/.workspace/evals/evals.json
+++ b/skills/handoff/.workspace/evals/evals.json
@@ -1,0 +1,57 @@
+{
+  "skill_name": "handoff",
+  "evals": [
+    {
+      "id": 1,
+      "name": "create-default-path",
+      "prompt": "We've been working on an Express.js API for about 2 hours. Here's what's been done: added JWT authentication middleware (src/middleware/auth.ts), created the /users and /posts route handlers, and written unit tests for both. The auth middleware has a known issue — it doesn't handle token refresh and will return 401 on expired tokens even when a valid refresh token exists. Pending work: implement token refresh logic in auth.ts, add rate limiting to the /posts endpoint, and write integration tests. Constraint: must stay compatible with the existing mobile app client which expects the current response shape. We're approaching the context limit. /handoff",
+      "expected_output": "Creates a valid JSON file in .claude/handoffs/ with a timestamped filename. The JSON contains schema_version 2.0.0, a meaningful task.goal, the token refresh issue in discovered_issues, the three pending steps, the API compatibility constraint in constraints, and the three modified files. Prints a summary to the user with task/completed/pending counts and a ready-to-paste resume_prompt. Tells the user to run /clear — does not run it itself.",
+      "files": [],
+      "expectations": [
+        "A JSON file is created inside a .claude/handoffs/ directory",
+        "The JSON contains schema_version set to exactly '2.0.0'",
+        "The JSON contains all required top-level fields: task, current_state, completed_steps, pending_steps, constraints, discovered_issues, modified_files, decisions, resume_prompt",
+        "task.goal is a single non-empty sentence",
+        "pending_steps contains at least the three items mentioned: token refresh, rate limiting, integration tests",
+        "discovered_issues references the auth token refresh problem",
+        "The output to the user includes 'Run /clear' or equivalent instruction to clear the context",
+        "resume_prompt references the handoff filename so the next agent can load it",
+        "The skill does NOT run /clear itself"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "create-explicit-filename",
+      "prompt": "I've spent this session designing a PostgreSQL schema for a multi-tenant SaaS app. Key decisions made: using row-level security (RLS) over separate schemas per tenant for cost reasons, settled on UUID primary keys, and chose JSONB for the flexible metadata column instead of EAV. Three migration files written so far (001_initial.sql, 002_rls_policies.sql, 003_indexes.sql). Still need to write the seed data script, document the RLS policy logic, and benchmark query performance under 1000 tenants. The constraint is that the schema must support eventual migration to CockroachDB — so no PostgreSQL-specific types that CockroachDB doesn't support. /handoff db-schema-work.json",
+      "expected_output": "Creates a JSON file at exactly db-schema-work.json in the current working directory. The JSON has schema_version 2.0.0, captures the three key decisions with their rationale and rejected alternatives, lists the three migration files in modified_files, includes the CockroachDB compatibility constraint, and sets resume_prompt to reference 'db-schema-work.json' by name.",
+      "files": [],
+      "expectations": [
+        "A file named exactly 'db-schema-work.json' is created (not in .claude/handoffs/, at the path specified)",
+        "The JSON contains schema_version set to exactly '2.0.0'",
+        "decisions array contains at least one entry with decision, rationale, and alternatives_rejected fields",
+        "The RLS vs separate schemas decision is captured with its cost rationale",
+        "modified_files lists all three migration SQL files",
+        "constraints includes the CockroachDB compatibility requirement",
+        "resume_prompt references 'db-schema-work.json' by name so the next agent can load it"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "resume-from-file",
+      "prompt": "Load the handoff at .workspace/evals/files/handoff-fixture.json and continue the work.",
+      "expected_output": "Reads the handoff file. Prints an oriented summary showing the task goal (React class-to-hooks migration), completed step count (3), pending step count (6), and the first pending step (UserProfile migration). Then begins work on pending_steps[0] — migrating UserProfile.tsx. Does not write a new handoff file unprompted.",
+      "files": [
+        ".workspace/evals/files/handoff-fixture.json"
+      ],
+      "expectations": [
+        "The agent reads the handoff fixture file",
+        "The oriented summary includes the task goal about React class-to-hooks migration",
+        "The summary shows 3 completed steps and 6 pending steps",
+        "The summary explicitly names UserProfile as the first pending step",
+        "The agent begins work on migrating UserProfile.tsx (the first pending step)",
+        "The agent does not write a new handoff JSON file unprompted",
+        "The agent references the discovered_issues note about getDerivedStateFromProps and the useEffect+useRef pattern"
+      ]
+    }
+  ]
+}

--- a/skills/handoff/.workspace/evals/files/handoff-fixture.json
+++ b/skills/handoff/.workspace/evals/files/handoff-fixture.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "2.0.0",
+  "generated_at": "2026-04-24T09:15:00Z",
+  "task": {
+    "goal": "Migrate all React class components in src/components/ to functional components with hooks",
+    "acceptance_criteria": [
+      "No React.Component or React.PureComponent references remain in src/components/",
+      "All existing Jest tests pass without modification",
+      "No visible change in app behaviour — same props API, same rendered output"
+    ]
+  },
+  "current_state": "8 of 14 components migrated. The straightforward stateless components are done. Remaining 6 all use lifecycle methods (componentDidMount, componentDidUpdate, componentWillUnmount) that need conversion to useEffect. One component (UserProfile) also uses getDerivedStateFromProps which needs special handling.",
+  "completed_steps": [
+    "Migrated Header, Footer, Button, Badge, Spinner, Card, Tag, and Avatar components",
+    "Confirmed all unit tests pass for migrated components",
+    "Added ESLint rule no-restricted-syntax to ban React.Component going forward"
+  ],
+  "pending_steps": [
+    "Migrate UserProfile component — has getDerivedStateFromProps, convert to useEffect + ref pattern",
+    "Migrate NotificationList component — uses componentDidMount for WebSocket subscription",
+    "Migrate DataTable component — complex componentDidUpdate with deep comparison",
+    "Migrate Modal, Tooltip, and Dropdown components — all use componentWillUnmount for cleanup",
+    "Run full test suite and verify zero regressions",
+    "Remove React.Component import from all files and confirm ESLint passes"
+  ],
+  "constraints": [
+    "Must not change the public props API of any component — callers must not need updating",
+    "Test files must not be modified — they are the acceptance criteria",
+    "Cannot upgrade React version — locked at 17.0.2 due to downstream dependency"
+  ],
+  "discovered_issues": [
+    "src/components/UserProfile.tsx — getDerivedStateFromProps is used to sync URL params into state; needs useEffect + useRef to avoid infinite loop",
+    "src/components/DataTable.tsx — componentDidUpdate does a deep equality check on props.data; lodash isEqual is already imported and can be used in the dependency array workaround"
+  ],
+  "modified_files": [
+    { "path": "src/components/Header.tsx", "status": "modified", "note": "Converted from class to FC; no lifecycle methods were present" },
+    { "path": "src/components/Footer.tsx", "status": "modified", "note": "Converted from class to FC" },
+    { "path": "src/components/Button.tsx", "status": "modified", "note": "Converted from class to FC; defaultProps moved to default params" },
+    { "path": "src/components/Badge.tsx", "status": "modified", "note": "Converted from class to FC" },
+    { "path": "src/components/Spinner.tsx", "status": "modified", "note": "Converted from class to FC" },
+    { "path": "src/components/Card.tsx", "status": "modified", "note": "Converted from class to FC" },
+    { "path": "src/components/Tag.tsx", "status": "modified", "note": "Converted from class to FC" },
+    { "path": "src/components/Avatar.tsx", "status": "modified", "note": "Converted from class to FC; removed shouldComponentUpdate, added React.memo" },
+    { "path": ".eslintrc.js", "status": "modified", "note": "Added no-restricted-syntax rule banning React.Component" }
+  ],
+  "decisions": [
+    {
+      "decision": "Use React.memo on Avatar instead of shouldComponentUpdate",
+      "rationale": "shouldComponentUpdate did a shallow prop comparison — React.memo is the direct functional equivalent and requires no custom logic",
+      "alternatives_rejected": ["Custom comparison function in React.memo — overkill for shallow comparison"]
+    },
+    {
+      "decision": "Move defaultProps to default parameter values, not a separate .defaultProps assignment",
+      "rationale": "React deprecated .defaultProps for function components in React 18; moving now avoids a future migration",
+      "alternatives_rejected": [".defaultProps assignment — deprecated", "Separate defaults object — adds indirection"]
+    }
+  ],
+  "resume_prompt": "Load .claude/handoffs/2026-04-24-091500-react-hooks-migration.json. Continue the React class-to-hooks migration. Next step: migrate UserProfile (src/components/UserProfile.tsx) — it uses getDerivedStateFromProps to sync URL params into state. Convert using useEffect + useRef to avoid the infinite loop described in discovered_issues. Do not modify any test files."
+}

--- a/skills/handoff/.workspace/evals/iteration-1/eval-1/with_skill/outputs/.claude/handoffs/2026-04-25-120000-express-jwt-api.json
+++ b/skills/handoff/.workspace/evals/iteration-1/eval-1/with_skill/outputs/.claude/handoffs/2026-04-25-120000-express-jwt-api.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "2.0.0",
+  "generated_at": "2026-04-25T12:00:00Z",
+  "task": {
+    "goal": "Build a JWT-authenticated Express.js REST API with /users and /posts endpoints, including middleware, route handlers, and tests.",
+    "acceptance_criteria": [
+      "JWT authentication middleware is in place and protects routes",
+      "Token refresh logic handles expired tokens gracefully (returns refresh result, not 401)",
+      "Rate limiting is applied to the /posts endpoint",
+      "Unit tests exist for auth middleware, /users, and /posts handlers",
+      "Integration tests cover the full request lifecycle",
+      "All responses remain compatible with the existing mobile app client's expected shape"
+    ]
+  },
+  "current_state": "The Express.js API has JWT authentication middleware, /users and /posts route handlers, and unit tests for both route modules. The auth middleware has a known defect: it does not attempt a token refresh when it encounters an expired access token — it immediately returns a 401 even when a valid refresh token is present in the request. Token refresh logic, rate limiting on /posts, and integration tests are all still pending.",
+  "completed_steps": [
+    "Created JWT authentication middleware at src/middleware/auth.ts",
+    "Created /users route handler",
+    "Created /posts route handler",
+    "Written unit tests for the /users route handler",
+    "Written unit tests for the /posts route handler"
+  ],
+  "pending_steps": [
+    "Implement token refresh logic in src/middleware/auth.ts so that expired access tokens trigger a refresh attempt before returning 401",
+    "Add rate limiting middleware to the /posts endpoint",
+    "Write integration tests covering the full request lifecycle for /users and /posts"
+  ],
+  "constraints": [
+    "All API responses must remain compatible with the existing mobile app client's expected response shape — do not change field names, types, or HTTP status codes for success paths"
+  ],
+  "discovered_issues": [
+    "src/middleware/auth.ts does not handle token refresh: when an access token is expired and a valid refresh token exists, the middleware incorrectly returns 401 instead of transparently refreshing the token"
+  ],
+  "modified_files": [
+    {
+      "path": "src/middleware/auth.ts",
+      "status": "created",
+      "note": "JWT authentication middleware; missing token-refresh handling for expired access tokens"
+    },
+    {
+      "path": "src/routes/users.ts",
+      "status": "created",
+      "note": "/users route handler with unit tests passing"
+    },
+    {
+      "path": "src/routes/posts.ts",
+      "status": "created",
+      "note": "/posts route handler with unit tests passing; rate limiting not yet added"
+    }
+  ],
+  "decisions": [
+    {
+      "decision": "Use JWT for authentication rather than sessions",
+      "rationale": "Stateless authentication suits the mobile client and avoids server-side session storage",
+      "alternatives_rejected": ["Cookie-based sessions"]
+    }
+  ],
+  "resume_prompt": "Resume from handoff file 2026-04-25-120000-express-jwt-api.json. The Express.js JWT API has auth middleware, /users and /posts handlers, and unit tests in place. The immediate priority is fixing the token-refresh bug in src/middleware/auth.ts (expired tokens should trigger a refresh attempt, not immediately return 401). Then add rate limiting to /posts and write integration tests. Hard constraint: do not change response shapes — the mobile client depends on them."
+}

--- a/skills/handoff/.workspace/evals/iteration-1/eval-1/with_skill/outputs/output.txt
+++ b/skills/handoff/.workspace/evals/iteration-1/eval-1/with_skill/outputs/output.txt
@@ -1,0 +1,16 @@
+Handoff written to: .claude/handoffs/2026-04-25-120000-express-jwt-api.json
+
+Summary:
+- Task: Build a JWT-authenticated Express.js REST API with /users and /posts endpoints, including middleware, route handlers, and tests.
+- Completed: 5 steps
+- Pending: 3 steps
+- Constraints: 1
+- Open issues: 1
+- Modified files: 3
+
+Next steps:
+1. Run /clear to wipe the context window
+2. Start a new session
+3. Paste this prompt to resume:
+
+"Resume from handoff file 2026-04-25-120000-express-jwt-api.json. The Express.js JWT API has auth middleware, /users and /posts handlers, and unit tests in place. The immediate priority is fixing the token-refresh bug in src/middleware/auth.ts (expired tokens should trigger a refresh attempt, not immediately return 401). Then add rate limiting to /posts and write integration tests. Hard constraint: do not change response shapes — the mobile client depends on them."

--- a/skills/handoff/.workspace/evals/iteration-1/eval-1/without_skill/outputs/output.txt
+++ b/skills/handoff/.workspace/evals/iteration-1/eval-1/without_skill/outputs/output.txt
@@ -1,0 +1,82 @@
+SESSION HANDOFF SUMMARY
+=======================
+Date: 2026-04-25
+Session Duration: ~2 hours
+Project: Express.js API
+
+---
+
+COMPLETED WORK
+--------------
+1. JWT Authentication Middleware
+   - File: src/middleware/auth.ts
+   - Status: Done, with known issue (see below)
+
+2. Route Handlers
+   - /users route handler — complete
+   - /posts route handler — complete
+
+3. Unit Tests
+   - Unit tests for /users — complete
+   - Unit tests for /posts — complete
+
+---
+
+KNOWN ISSUE
+-----------
+Location: src/middleware/auth.ts
+Description: Token refresh is not handled. When a JWT is expired, the
+middleware returns 401 even if the client has a valid refresh token.
+The correct behavior should be: detect expired token, check for valid
+refresh token, issue new access token, and continue the request.
+
+Impact: Mobile app clients that rely on refresh token flows will be
+logged out on token expiry instead of receiving a refreshed token
+transparently.
+
+---
+
+PENDING WORK
+------------
+Priority order based on dependencies:
+
+1. Token Refresh Logic (src/middleware/auth.ts)
+   - Detect token expiration separately from other JWT errors
+   - Extract and validate the refresh token from the request
+   - Issue a new access token and attach it to the response
+   - Continue processing the original request
+   - CONSTRAINT: Response shape must stay compatible with the existing
+     mobile app client — do not change response envelope structure or
+     field names
+
+2. Rate Limiting for /posts Endpoint
+   - Add rate limiting middleware to the /posts route only
+   - Choose an appropriate window and request limit
+   - Ensure rate-limit error responses match the existing response shape
+     expected by the mobile client
+
+3. Integration Tests
+   - Cover the full request lifecycle (auth middleware + route handlers)
+   - Include scenarios: valid token, expired token + valid refresh,
+     expired token + invalid refresh, rate limit exceeded
+   - These depend on items 1 and 2 being complete first
+
+---
+
+CONSTRAINTS
+-----------
+- The existing mobile app client expects the current response shape.
+  All changes must preserve the existing response envelope and field names.
+  Verify any new error responses (401, 429, etc.) match the shape the
+  client already handles.
+
+---
+
+CONTEXT FOR NEXT SESSION
+-------------------------
+- auth.ts already has the JWT verification logic in place; the gap is
+  specifically the refresh-token branch that is missing.
+- Unit tests for routes already pass — do not break them.
+- Integration tests are net-new and should be added after pending features
+  are implemented.
+- No database schema changes should be needed for the above tasks.

--- a/skills/handoff/.workspace/evals/iteration-1/eval-2/with_skill/outputs/db-schema-work.json
+++ b/skills/handoff/.workspace/evals/iteration-1/eval-2/with_skill/outputs/db-schema-work.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "2.0.0",
+  "generated_at": "2026-04-25T00:00:00Z",
+  "task": {
+    "goal": "Design and implement a PostgreSQL schema for a multi-tenant SaaS application with row-level security and CockroachDB migration compatibility.",
+    "acceptance_criteria": [
+      "Schema enforces tenant isolation via RLS policies",
+      "UUID primary keys used throughout",
+      "JSONB used for flexible metadata columns",
+      "All migration files applied cleanly (001, 002, 003)",
+      "Seed data script exists and runs without errors",
+      "RLS policy logic is documented",
+      "Query performance benchmarked under 1000-tenant load",
+      "Schema uses only data types supported by CockroachDB"
+    ]
+  },
+  "current_state": "Three migration files have been written covering the initial schema (001_initial.sql), RLS policies (002_rls_policies.sql), and indexes (003_indexes.sql). Key architectural decisions are finalised: RLS for tenant isolation, UUID primary keys, and JSONB for flexible metadata. The schema has not yet been seeded, the RLS policy logic lacks written documentation, and no performance benchmarks have been run.",
+  "completed_steps": [
+    "Decided on row-level security (RLS) over separate per-tenant schemas",
+    "Settled on UUID primary keys for all tables",
+    "Chose JSONB over EAV for flexible metadata columns",
+    "Wrote 001_initial.sql — initial schema migration",
+    "Wrote 002_rls_policies.sql — RLS policy definitions",
+    "Wrote 003_indexes.sql — index creation migration",
+    "Identified CockroachDB compatibility as a hard constraint and validated type choices against it"
+  ],
+  "pending_steps": [
+    "Write the seed data script for development and testing",
+    "Document the RLS policy logic (which policies exist, what they enforce, and why)",
+    "Benchmark query performance under a simulated 1000-tenant load",
+    "Verify all migration files apply cleanly in sequence on a fresh database",
+    "Confirm each data type used is supported by CockroachDB"
+  ],
+  "constraints": [
+    "Schema must be compatible with eventual migration to CockroachDB — no PostgreSQL-specific types unsupported by CockroachDB (e.g. avoid SERIAL in favour of UUID, avoid pg-specific range types if CockroachDB lacks them)",
+    "Tenant isolation must be enforced at the database level via RLS, not application logic alone"
+  ],
+  "discovered_issues": [
+    "RLS policy logic has not been documented — intent and coverage of each policy is currently implicit in SQL only",
+    "No performance validation has been done; behaviour under 1000+ tenants is unknown"
+  ],
+  "modified_files": [
+    {
+      "path": "migrations/001_initial.sql",
+      "status": "created",
+      "note": "Initial schema: tables with UUID PKs and JSONB metadata column"
+    },
+    {
+      "path": "migrations/002_rls_policies.sql",
+      "status": "created",
+      "note": "Row-level security policies for tenant isolation"
+    },
+    {
+      "path": "migrations/003_indexes.sql",
+      "status": "created",
+      "note": "Index definitions to support multi-tenant query patterns"
+    }
+  ],
+  "decisions": [
+    {
+      "decision": "Use row-level security (RLS) for tenant isolation rather than separate schemas per tenant",
+      "rationale": "Separate schemas multiply infrastructure cost and operational complexity; RLS keeps a single schema while enforcing tenant boundaries at the database level",
+      "alternatives_rejected": ["Separate PostgreSQL schema per tenant", "Application-layer tenant filtering only"]
+    },
+    {
+      "decision": "Use UUID primary keys throughout",
+      "rationale": "UUIDs are portable, avoid sequential ID leakage across tenants, and are natively supported by CockroachDB",
+      "alternatives_rejected": ["SERIAL / BIGSERIAL auto-increment integers (PostgreSQL-specific and not recommended in CockroachDB)"]
+    },
+    {
+      "decision": "Use JSONB for the flexible metadata column",
+      "rationale": "JSONB allows schema-flexible per-tenant attributes without the query complexity and join overhead of an EAV model; CockroachDB supports JSONB",
+      "alternatives_rejected": ["Entity-Attribute-Value (EAV) pattern", "Plain TEXT JSON column without binary indexing"]
+    }
+  ],
+  "resume_prompt": "I'm resuming work on a multi-tenant SaaS PostgreSQL schema. Load the handoff file db-schema-work.json for full context. In summary: three migration files (001_initial.sql, 002_rls_policies.sql, 003_indexes.sql) are written using RLS for tenant isolation, UUID PKs, and JSONB metadata. The schema must stay CockroachDB-compatible. Next I need to: (1) write the seed data script, (2) document the RLS policy logic, and (3) benchmark query performance under 1000 tenants. Please start with the seed data script."
+}

--- a/skills/handoff/.workspace/evals/iteration-1/eval-2/with_skill/outputs/output.txt
+++ b/skills/handoff/.workspace/evals/iteration-1/eval-2/with_skill/outputs/output.txt
@@ -1,0 +1,16 @@
+Handoff written to: db-schema-work.json
+
+Summary:
+- Task: Design and implement a PostgreSQL schema for a multi-tenant SaaS application with row-level security and CockroachDB migration compatibility.
+- Completed: 7 steps
+- Pending: 5 steps
+- Constraints: 2
+- Open issues: 2
+- Modified files: 3
+
+Next steps:
+1. Run /clear to wipe the context window
+2. Start a new session
+3. Paste this prompt to resume:
+
+"I'm resuming work on a multi-tenant SaaS PostgreSQL schema. Load the handoff file db-schema-work.json for full context. In summary: three migration files (001_initial.sql, 002_rls_policies.sql, 003_indexes.sql) are written using RLS for tenant isolation, UUID PKs, and JSONB metadata. The schema must stay CockroachDB-compatible. Next I need to: (1) write the seed data script, (2) document the RLS policy logic, and (3) benchmark query performance under 1000 tenants. Please start with the seed data script."

--- a/skills/handoff/.workspace/evals/iteration-1/eval-2/without_skill/outputs/output.txt
+++ b/skills/handoff/.workspace/evals/iteration-1/eval-2/without_skill/outputs/output.txt
@@ -1,0 +1,78 @@
+USER MESSAGE:
+"I've spent this session designing a PostgreSQL schema for a multi-tenant SaaS app. Key decisions made: using row-level security (RLS) over separate schemas per tenant for cost reasons, settled on UUID primary keys, and chose JSONB for the flexible metadata column instead of EAV. Three migration files written so far (001_initial.sql, 002_rls_policies.sql, 003_indexes.sql). Still need to write the seed data script, document the RLS policy logic, and benchmark query performance under 1000 tenants. The constraint is that the schema must support eventual migration to CockroachDB — so no PostgreSQL-specific types that CockroachDB doesn't support. /handoff db-schema-work.json"
+
+---
+
+RESPONSE (without handoff skill):
+
+I can see you're trying to invoke /handoff to create a structured handoff document (db-schema-work.json), but that skill isn't available in this session. I'll do my best to capture the session context manually.
+
+Here's a summary of what you've described, organized so it could be picked up by another agent or resumed in a future session:
+
+---
+
+## Session Summary: Multi-Tenant PostgreSQL Schema Design
+
+### Decisions Made
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Tenant isolation strategy | Row-Level Security (RLS) | Cost — separate schemas per tenant is more expensive |
+| Primary key type | UUID | Consistent, distributed-safe |
+| Flexible metadata column | JSONB | Chosen over EAV (Entity-Attribute-Value) pattern |
+| CockroachDB compatibility | Required | No PostgreSQL-specific types that CockroachDB doesn't support |
+
+### CockroachDB Compatibility Notes
+
+Given the CockroachDB constraint, watch out for:
+- `SERIAL` / `BIGSERIAL` — use `UUID` (already done) or `gen_random_uuid()`
+- `JSONB` is supported in CockroachDB, so that choice is safe
+- RLS is supported in CockroachDB (as of v22.2+), but verify policy syntax compatibility
+- Avoid `EXCLUDE` constraints — not supported in CockroachDB
+- Avoid `DEFERRABLE` constraints — limited support
+- Avoid `pg_trgm` or other PostgreSQL-specific extensions in indexes
+
+### Migration Files Written
+
+1. `001_initial.sql` — initial schema
+2. `002_rls_policies.sql` — RLS policy definitions
+3. `003_indexes.sql` — index definitions
+
+### Remaining Work
+
+1. **Seed data script** — create representative tenant + row data for testing
+2. **Document RLS policy logic** — explain the intent and mechanics of each policy in `002_rls_policies.sql`
+3. **Benchmark query performance under 1000 tenants** — load test with realistic data volume
+
+### Suggested Next Steps for Seed Script
+
+```sql
+-- Suggested seed structure (adjust to your actual schema)
+INSERT INTO tenants (id, name) VALUES
+  (gen_random_uuid(), 'Tenant Alpha'),
+  (gen_random_uuid(), 'Tenant Beta');
+
+-- Use a loop or generate_series() to create 1000 tenants for benchmarking:
+INSERT INTO tenants (id, name)
+SELECT gen_random_uuid(), 'Tenant ' || i
+FROM generate_series(1, 1000) AS s(i);
+```
+
+Note: `generate_series()` is supported in CockroachDB, so this is safe.
+
+### RLS Documentation Template
+
+For `002_rls_policies.sql`, each policy should be documented with:
+- **Policy name** and target table
+- **Command** (SELECT, INSERT, UPDATE, DELETE, or ALL)
+- **Using clause** — the row-visible condition (e.g., `tenant_id = current_setting('app.current_tenant')::uuid`)
+- **With check clause** — the write-permitted condition
+- **How `current_setting` is set** — typically via a `SET LOCAL` at the start of each transaction
+
+---
+
+## What /handoff Would Have Done
+
+The `/handoff` command would have written a structured JSON file (`db-schema-work.json`) capturing this context in a machine-readable format — including decisions, file paths, remaining tasks, and constraints — suitable for loading into a new session or handing off to another agent. Without that skill, this plain-text summary is the best alternative.
+
+If you want to preserve this in a reusable format, I can write the JSON manually to `db-schema-work.json` in your desired output location. Just let me know.

--- a/skills/handoff/.workspace/evals/iteration-1/eval-3/with_skill/outputs/output.txt
+++ b/skills/handoff/.workspace/evals/iteration-1/eval-3/with_skill/outputs/output.txt
@@ -1,0 +1,186 @@
+Loaded handoff: handoff-fixture.json
+
+- Task: Migrate all React class components in src/components/ to functional components with hooks
+- Completed: 3 steps
+- Pending: 6 steps
+- First step: Migrate UserProfile component — has getDerivedStateFromProps, convert to useEffect + ref pattern
+- Open issues: 2
+- Constraints: 3
+
+---
+
+Beginning work on pending_steps[0]: Migrate UserProfile component
+
+The discovered issue notes that getDerivedStateFromProps in UserProfile.tsx syncs URL params
+into state, and the conversion must use useEffect + useRef to avoid an infinite loop.
+
+Constraints in force:
+- Must not change the public props API — callers must not need updating
+- Test files must not be modified
+- React is locked at 17.0.2
+
+---
+
+MIGRATION: src/components/UserProfile.tsx
+
+The class component pattern being replaced looks like this:
+
+  class UserProfile extends React.Component<Props, State> {
+    static getDerivedStateFromProps(props: Props, state: State): Partial<State> | null {
+      if (props.urlParams.userId !== state.lastSeenUserId) {
+        return {
+          userId: props.urlParams.userId,
+          lastSeenUserId: props.urlParams.userId,
+        };
+      }
+      return null;
+    }
+
+    state: State = {
+      userId: this.props.urlParams.userId,
+      lastSeenUserId: this.props.urlParams.userId,
+    };
+
+    componentDidMount() {
+      this.fetchUser(this.state.userId);
+    }
+
+    componentDidUpdate(prevProps: Props) {
+      if (prevProps.urlParams.userId !== this.props.urlParams.userId) {
+        this.fetchUser(this.props.urlParams.userId);
+      }
+    }
+
+    componentWillUnmount() {
+      this.cancelPendingRequests();
+    }
+    ...
+  }
+
+Why getDerivedStateFromProps creates an infinite loop risk in hooks:
+- getDerivedStateFromProps fires on every render to keep state in sync with props.
+- A naive translation using useState + setState inside render would trigger a re-render
+  on every call, causing an infinite loop.
+- The correct pattern is: derive the value directly from props (no state copy needed),
+  OR use a ref to track the "previous" prop value and only call setState (triggering
+  a re-render) when the value actually changes.
+
+In this specific case (syncing urlParams.userId into state):
+- The state copy of userId only existed so getDerivedStateFromProps could track whether
+  it had changed. That tracking role is replaced by useRef.
+- The fetch side-effect (previously split across componentDidMount and componentDidUpdate)
+  collapses into a single useEffect with [userId] as its dependency.
+- Cleanup (componentWillUnmount) moves into the useEffect cleanup return.
+
+CONVERTED FUNCTIONAL COMPONENT:
+
+  import React, { useState, useEffect, useRef, useCallback } from 'react';
+
+  // Props interface — unchanged to preserve the public API
+  interface Props {
+    urlParams: { userId: string };
+    // ...any other existing props
+  }
+
+  const UserProfile: React.FC<Props> = ({ urlParams, ...rest }) => {
+    // Derive userId directly from props — no need to mirror it into state.
+    // This eliminates the getDerivedStateFromProps pattern entirely.
+    const userId = urlParams.userId;
+
+    // useRef holds a mutable value that does NOT trigger re-renders when changed.
+    // We use it to track the abort controller for in-flight requests so cleanup
+    // works correctly across re-renders (replaces cancelPendingRequests logic).
+    const abortControllerRef = useRef<AbortController | null>(null);
+
+    // Local UI state (loading, error, data) — unrelated to the GDSP pattern.
+    const [userData, setUserData] = useState<UserData | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<Error | null>(null);
+
+    const fetchUser = useCallback(async (id: string) => {
+      // Cancel any in-flight request before starting a new one.
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchUserById(id, { signal: controller.signal });
+        if (!controller.signal.aborted) {
+          setUserData(data);
+        }
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          setError(err as Error);
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    }, []); // no deps — fetchUserById is a stable module-level import
+
+    // Single useEffect replaces componentDidMount + componentDidUpdate + getDerivedStateFromProps.
+    // Runs on mount and whenever userId changes — exactly the class component behaviour.
+    useEffect(() => {
+      fetchUser(userId);
+
+      // Cleanup replaces componentWillUnmount — aborts any in-flight request.
+      return () => {
+        abortControllerRef.current?.abort();
+      };
+    }, [userId, fetchUser]);
+
+    // Render output is identical to the class component's render() method.
+    // Props API is unchanged — callers pass the same props as before.
+    if (loading) return <Spinner />;
+    if (error) return <ErrorMessage error={error} />;
+    if (!userData) return null;
+
+    return (
+      <div className="user-profile">
+        {/* ...same JSX as before... */}
+      </div>
+    );
+  };
+
+  export default UserProfile;
+
+KEY DECISIONS for this migration:
+
+1. Eliminated the state mirror of userId entirely.
+   - getDerivedStateFromProps existed solely to copy urlParams.userId into state so
+     componentDidUpdate could compare old vs new. In a functional component, the prop
+     IS the value — no copy needed. Reading urlParams.userId directly from props on
+     every render is safe and correct.
+
+2. useRef for the abort controller (not useState).
+   - The abort controller is imperative infrastructure, not UI state. Storing it in a
+     ref means updating it never triggers a re-render, which avoids the infinite loop
+     that would result from putting it in useState.
+
+3. Single useEffect with [userId] dependency collapses three lifecycle methods.
+   - componentDidMount  → runs on mount (empty dep array would also work, but [userId]
+     correctly re-fetches if userId changes before mount completes in concurrent mode).
+   - getDerivedStateFromProps + componentDidUpdate → React re-runs the effect whenever
+     userId changes, which is exactly when the class component triggered a fetch.
+   - componentWillUnmount → the cleanup function returned from useEffect.
+
+4. No infinite loop risk.
+   - The only state setters called inside the effect are setUserData, setLoading, and
+     setError. None of these are in the dependency array, so changing them does not
+     re-trigger the effect. userId comes from props and only changes when the caller
+     passes a new value — matching the class component's behaviour exactly.
+
+5. Public props API preserved.
+   - The component still accepts { urlParams: { userId: string }, ...rest } — no
+     caller changes required. This satisfies constraint #1.
+
+6. Test files untouched.
+   - No test file changes are needed or made. This satisfies constraint #2.
+
+---
+
+Next pending step (after UserProfile is merged and tests confirmed):
+  Migrate NotificationList component — uses componentDidMount for WebSocket subscription

--- a/skills/handoff/.workspace/evals/iteration-1/eval-3/without_skill/outputs/output.txt
+++ b/skills/handoff/.workspace/evals/iteration-1/eval-3/without_skill/outputs/output.txt
@@ -1,0 +1,117 @@
+Handoff loaded. Here is a summary of where things stand and how I will proceed.
+
+---
+
+CURRENT STATE
+=============
+
+Migration progress: 8 of 14 components converted.
+
+Completed:
+- Header, Footer, Button, Badge, Spinner, Card, Tag, Avatar
+- All unit tests pass for migrated components
+- ESLint rule added to ban React.Component going forward
+
+Remaining (6 components, all with lifecycle methods):
+1. UserProfile — getDerivedStateFromProps (sync URL params into state)
+2. NotificationList — componentDidMount (WebSocket subscription)
+3. DataTable — componentDidUpdate with deep comparison (lodash isEqual available)
+4. Modal — componentWillUnmount (cleanup)
+5. Tooltip — componentWillUnmount (cleanup)
+6. Dropdown — componentWillUnmount (cleanup)
+
+Constraints in force:
+- Props API must not change — callers must not need updating
+- Test files must not be modified
+- React version stays at 17.0.2
+
+---
+
+PLAN
+====
+
+I will work through the 6 remaining components in this order, from most complex to least:
+
+Step 1: UserProfile (src/components/UserProfile.tsx)
+------------------------------------------------------
+This is the trickiest case. getDerivedStateFromProps is being used to sync URL params into state.
+
+The correct functional equivalent is:
+
+  - Hold the previous URL param value in a useRef (prevUrlParamsRef).
+  - In the render body, compare the current URL param prop against the ref.
+  - If they differ, update state immediately (synchronous setState during render — allowed in React for this exact pattern, equivalent to getDerivedStateFromProps).
+  - After updating, write the new value into the ref so the next render sees it.
+
+This avoids the infinite loop because the state update is conditional (only fires when the value actually changed), and the ref tracks the last-synced value without triggering re-renders.
+
+Skeleton:
+
+  const prevUrlParamsRef = useRef(props.urlParams);
+  const [syncedState, setSyncedState] = useState(() => deriveState(props.urlParams));
+
+  if (props.urlParams !== prevUrlParamsRef.current) {
+    prevUrlParamsRef.current = props.urlParams;
+    setSyncedState(deriveState(props.urlParams));
+  }
+
+Do NOT put this logic inside a useEffect — that fires after paint and causes a flicker (two renders visible to the user). The synchronous-during-render pattern is the correct match for getDerivedStateFromProps.
+
+Step 2: NotificationList (src/components/NotificationList.tsx)
+--------------------------------------------------------------
+componentDidMount for a WebSocket subscription maps directly to useEffect with an empty dependency array [].
+
+  useEffect(() => {
+    const ws = subscribeToNotifications(...);
+    return () => ws.close(); // cleanup equivalent to componentWillUnmount
+  }, []);
+
+Step 3: DataTable (src/components/DataTable.tsx)
+------------------------------------------------
+componentDidUpdate with a deep comparison on props.data.
+
+The challenge: useEffect dependency arrays use reference equality, but props.data changes reference even when content is the same.
+
+Workaround using the ref pattern:
+  - Keep a ref holding the last props.data value.
+  - Inside useEffect (with props.data in deps), compare using lodash isEqual.
+  - Only run the expensive logic when the content actually differs.
+
+  const prevDataRef = useRef(props.data);
+
+  useEffect(() => {
+    if (!isEqual(props.data, prevDataRef.current)) {
+      prevDataRef.current = props.data;
+      // ... run the update logic
+    }
+  }, [props.data]);
+
+This mirrors the componentDidUpdate guard exactly.
+
+Step 4–6: Modal, Tooltip, Dropdown
+-----------------------------------
+All three only need componentWillUnmount cleanup. This is the simplest case:
+
+  useEffect(() => {
+    return () => {
+      // cleanup code from componentWillUnmount
+    };
+  }, []);
+
+These three can be done quickly once the harder components are complete.
+
+Step 7: Full test suite + ESLint check
+---------------------------------------
+After all 6 components are migrated:
+- Run Jest: all tests must pass without modification to test files.
+- Run ESLint: no React.Component references should remain; the no-restricted-syntax rule will catch any slip.
+- Confirm no React.Component or React.PureComponent imports remain in src/components/.
+
+---
+
+STARTING NOW: UserProfile
+==========================
+
+The next action is to open src/components/UserProfile.tsx, identify exactly how getDerivedStateFromProps is structured, and apply the useRef + synchronous-during-render conversion described above.
+
+Please share the file contents (or confirm I have filesystem access) and I will proceed with the migration immediately.

--- a/skills/handoff/.workspace/evals/trigger-evals.json
+++ b/skills/handoff/.workspace/evals/trigger-evals.json
@@ -1,0 +1,102 @@
+[
+  {
+    "query": "/handoff",
+    "should_trigger": true,
+    "notes": "Explicit command — must trigger"
+  },
+  {
+    "query": "/handoff auth-refactor.json",
+    "should_trigger": true,
+    "notes": "Explicit command with filename — must trigger"
+  },
+  {
+    "query": "We're getting close to the context limit. Save the session before we clear.",
+    "should_trigger": true,
+    "notes": "Context limit + save intent — core use case"
+  },
+  {
+    "query": "I need to hand this work off to another agent. Can you capture the current state?",
+    "should_trigger": true,
+    "notes": "Sub-agent delegation — explicit in description"
+  },
+  {
+    "query": "context rot is kicking in, lets do a handoff before things get worse",
+    "should_trigger": true,
+    "notes": "Casual phrasing with typo — real user speech pattern"
+  },
+  {
+    "query": "Load the handoff at .claude/handoffs/2026-04-23-143022-auth.json",
+    "should_trigger": true,
+    "notes": "RESUME mode — explicit file path"
+  },
+  {
+    "query": "continue where we left off — there should be a handoff file from last session",
+    "should_trigger": true,
+    "notes": "RESUME mode — implicit, no filename given"
+  },
+  {
+    "query": "save state, I'm switching to a fresh session to avoid context degradation",
+    "should_trigger": true,
+    "notes": "'save state' is listed in the description triggers"
+  },
+  {
+    "query": "I'm pausing here for today. Create a handoff so I can pick this up tomorrow.",
+    "should_trigger": true,
+    "notes": "End-of-session handoff — pause and resume across time"
+  },
+  {
+    "query": "resume from my last handoff",
+    "should_trigger": true,
+    "notes": "RESUME trigger — terse, no path specified"
+  },
+  {
+    "query": "Can you save this config to a JSON file called settings.json?",
+    "should_trigger": false,
+    "notes": "File write, not session handoff — shares 'save' and 'JSON' keywords"
+  },
+  {
+    "query": "Commit my changes and push to the feature branch",
+    "should_trigger": false,
+    "notes": "Git operation — 'save' intent but not session state"
+  },
+  {
+    "query": "I want to use /compact to trim the context window",
+    "should_trigger": false,
+    "notes": "Explicitly wants /compact not handoff — respect user's stated preference"
+  },
+  {
+    "query": "Write a summary of everything we've done in this session",
+    "should_trigger": false,
+    "notes": "Summary request — similar intent but no save/resume workflow"
+  },
+  {
+    "query": "Export the current database records to output.json",
+    "should_trigger": false,
+    "notes": "Data export to JSON — shares format but not session state"
+  },
+  {
+    "query": "Let's start this problem from scratch, forget what we've done",
+    "should_trigger": false,
+    "notes": "Reset intent without saving — user wants /clear only, not handoff"
+  },
+  {
+    "query": "Create a new session and start fresh on the API design",
+    "should_trigger": false,
+    "notes": "New session without save intent — no handoff needed"
+  },
+  {
+    "query": "What's the current status of the auth work?",
+    "should_trigger": false,
+    "notes": "Status question — not a save or resume action"
+  },
+  {
+    "query": "Document what we've built so far in a markdown file",
+    "should_trigger": false,
+    "notes": "Documentation request — writing docs, not saving session state"
+  },
+  {
+    "query": "Can you read the file at src/auth/token-service.ts and explain it?",
+    "should_trigger": false,
+    "notes": "File read + explanation — no session state action"
+  }
+]

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: handoff
+description: >
+  Make sure to use this skill whenever the user types /handoff (with or without a
+  filename argument), says "handoff", "save state", "context rot", "save session",
+  "create a handoff", "I need a clean start", wants to snapshot progress before
+  clearing context or switching sessions, is approaching the context limit
+  (300–400k tokens), or wants to delegate the current session state to another agent.
+  Also invoke for RESUME mode: when the user says "load handoff", "resume from [file]",
+  "continue where we left off", "pick up where I left off", "load the handoff at
+  [path]", references a .claude/handoffs/ file path, or says there is a handoff file
+  from a prior session. Creates or loads a structured JSON snapshot capturing goals,
+  decisions, completed steps, pending work, constraints, and modified files so work
+  can continue cleanly in a new session.
+allowed-tools: Read, Write
+---
+
+# Handoff
+
+Saves or loads a structured JSON snapshot of session state. Use the schema in `references/schema.md` for all fields.
+
+---
+
+## Mode Selection
+
+- **User wants to save / pause / context is full** → CREATE workflow
+- **User wants to resume / load / continue** → RESUME workflow
+- **After 5+ file edits or a major decision** → suggest: *"We've made good progress — say 'create handoff' when you're ready to save state and start fresh."*
+
+---
+
+## CREATE Workflow
+
+### Step 1 — Determine Output File
+
+Use the user's argument if provided (e.g. `/handoff auth-work.json`). Otherwise default
+to `.claude/handoffs/YYYY-MM-DD-HHMMSS-<slug>.json` in the project root, where `<slug>`
+is 2–4 words from the task goal (e.g. `auth-refactor`, `payment-api`). Create
+`.claude/handoffs/` if it doesn't exist.
+
+### Step 2 — Analyse the Session
+
+Review the full conversation and all modified files, then extract:
+
+- The primary goal and what "done" looks like (acceptance criteria)
+- All architectural and design decisions reached, with rationale
+- What has been completed and can be verified
+- What still needs to be done, in priority order
+- Hard constraints and non-negotiables
+- Known bugs, issues, or unresolved warnings
+- Which files were changed and what was done to each
+
+### Step 3 — Write the Handoff File
+
+Write the JSON using the schema in `references/schema.md`. Do not omit any top-level
+field — use `[]` if there is nothing to report.
+
+### Step 4 — Confirm and Guide the User
+
+```
+Handoff written to: <filename>
+
+Summary:
+- Task: <goal>
+- Completed: <N> steps
+- Pending: <N> steps
+- Constraints: <N>
+- Open issues: <N>
+- Modified files: <N>
+
+Next steps:
+1. Run /clear to wipe the context window
+2. Start a new session
+3. Paste this prompt to resume:
+
+"<resume_prompt value>"
+```
+
+> Do **not** run `/clear` yourself — the user must do this manually.
+
+---
+
+## RESUME Workflow
+
+### Step 1 — Locate the File
+
+Use the user's argument if given. Otherwise read `.claude/handoffs/` and pick the most
+recent file by filename timestamp. If the directory is empty or missing, tell the user.
+
+### Step 2 — Load and Orient
+
+Read the file fully. Then report:
+
+```
+Loaded handoff: <filename>
+
+- Task: <goal>
+- Completed: <N> steps
+- Pending: <N> steps
+- First step: <pending_steps[0]>
+- Open issues: <N>
+- Constraints: <N>
+```
+
+### Step 3 — Begin Work
+
+Start immediately with `pending_steps[0]`. Keep `constraints`, `discovered_issues`, and
+`decisions` visible as you work — don't re-litigate choices already made.
+
+---
+
+## Reference Files
+
+- `references/schema.md` — full JSON schema, field rules, and a complete example

--- a/skills/handoff/references/schema.md
+++ b/skills/handoff/references/schema.md
@@ -1,0 +1,131 @@
+# Handoff Schema v2.0.0
+
+## Full Schema
+
+```json
+{
+  "schema_version": "2.0.0",
+  "generated_at": "<ISO 8601 UTC timestamp>",
+  "task": {
+    "goal": "<one sentence — plain English, no jargon>",
+    "acceptance_criteria": [
+      "<testable criterion 1>",
+      "<testable criterion 2>"
+    ]
+  },
+  "current_state": "<one paragraph describing where things stand right now>",
+  "completed_steps": [
+    "<past tense, verifiably done>"
+  ],
+  "pending_steps": [
+    "<imperative, ordered by priority — first item is the next action>"
+  ],
+  "constraints": [
+    "<hard limit that must not be violated>"
+  ],
+  "discovered_issues": [
+    "<known unfixed problem — include file path and symptom when known>"
+  ],
+  "modified_files": [
+    {
+      "path": "<repo-relative path>",
+      "status": "<created | modified | deleted>",
+      "note": "<one-line description of what changed>"
+    }
+  ],
+  "decisions": [
+    {
+      "decision": "<what was decided>",
+      "rationale": "<why>",
+      "alternatives_rejected": ["<option A>", "<option B>"]
+    }
+  ],
+  "resume_prompt": "<ready-to-paste prompt for the new session — reference the handoff file by name>"
+}
+```
+
+## Field Rules
+
+| Field | Rules |
+|---|---|
+| `schema_version` | Always `"2.0.0"` |
+| `generated_at` | ISO 8601 UTC, e.g. `"2026-04-23T14:32:00Z"` |
+| `task.goal` | One sentence. Plain English, no jargon. |
+| `task.acceptance_criteria` | At least one entry. Must be testable/verifiable. |
+| `completed_steps` | Past tense. Only steps that are verifiably done. |
+| `pending_steps` | Imperative. Ordered by priority. First item = next action. |
+| `constraints` | Hard limits — things that must not be violated. |
+| `discovered_issues` | Known unfixed problems. Include file paths when known. |
+| `modified_files` | Every file the session touched. Use repo-relative paths. |
+| `modified_files[].status` | One of: `created` · `modified` · `deleted` |
+| `decisions` | Architectural/design choices — always include rationale. |
+| `resume_prompt` | Complete, ready-to-use prompt. Must name the handoff file. |
+
+## Example
+
+```json
+{
+  "schema_version": "2.0.0",
+  "generated_at": "2026-04-23T14:32:00Z",
+  "task": {
+    "goal": "Refactor auth middleware to store tokens in httpOnly cookies instead of localStorage",
+    "acceptance_criteria": [
+      "All token read/write operations go through TokenService",
+      "No token values are written to localStorage or sessionStorage",
+      "Existing /login and /refresh API contracts are unchanged",
+      "All existing auth tests pass"
+    ]
+  },
+  "current_state": "TokenService class created and JWT validation logic migrated. Unit tests for TokenService pass. SessionStore and the legacy /login route still reference the old token helpers directly.",
+  "completed_steps": [
+    "Created src/auth/token-service.ts with full token lifecycle methods",
+    "Migrated JWT validation from auth-middleware.ts into TokenService",
+    "Updated unit tests for TokenService — all passing"
+  ],
+  "pending_steps": [
+    "Update SessionStore to call TokenService instead of token helpers",
+    "Update legacy /login route to use TokenService",
+    "Write integration test for full auth flow end-to-end",
+    "Delete deprecated token helper functions"
+  ],
+  "constraints": [
+    "Must not break existing /login and /refresh API contracts",
+    "All tokens must be set as httpOnly, Secure, SameSite=Strict cookies",
+    "Session TTL is 15 minutes — must be enforced in TokenService, not middleware"
+  ],
+  "discovered_issues": [
+    "src/auth/token-service.ts — TokenService.validate() has an off-by-one on expiry check (expiresAt <= now instead of < now)",
+    "src/routes/login.ts — still bypasses TokenService entirely, must be updated"
+  ],
+  "modified_files": [
+    {
+      "path": "src/auth/token-service.ts",
+      "status": "created",
+      "note": "New — JWT validation + cookie management. Off-by-one on expiry (pending fix)."
+    },
+    {
+      "path": "src/auth/auth-middleware.ts",
+      "status": "modified",
+      "note": "JWT validation removed; now delegates to TokenService.validate()"
+    },
+    {
+      "path": "tests/auth/token-service.test.ts",
+      "status": "created",
+      "note": "Unit tests for TokenService — all passing"
+    }
+  ],
+  "decisions": [
+    {
+      "decision": "Use httpOnly cookies for all token storage",
+      "rationale": "Legal/compliance requirement — session tokens must not be accessible via JavaScript",
+      "alternatives_rejected": ["localStorage", "sessionStorage", "in-memory store"]
+    },
+    {
+      "decision": "Centralise all token logic in TokenService",
+      "rationale": "Removes scattered token handling from middleware and routes; single place to enforce cookie policy",
+      "alternatives_rejected": ["Patch each route individually"]
+    }
+  ],
+  "resume_prompt": "Load context-handoff.json. Continue the auth middleware refactor. Next step: update SessionStore (src/auth/session-store.ts) to call TokenService instead of the legacy token helpers. Also fix the off-by-one on TokenService.validate() expiry check before proceeding."
+}
+```

--- a/skills/readme-writer/.workspace/evals/trigger-evals.json
+++ b/skills/readme-writer/.workspace/evals/trigger-evals.json
@@ -1,0 +1,102 @@
+[
+  {
+    "query": "write a readme for my project",
+    "should_trigger": true,
+    "notes": "Canonical direct trigger — exact phrase covered by description"
+  },
+  {
+    "query": "document this project — it has no README at all",
+    "should_trigger": true,
+    "notes": "'document this project' is an explicit trigger phrase in the description"
+  },
+  {
+    "query": "make a readme for my repo, it's a CLI that compresses git history",
+    "should_trigger": true,
+    "notes": "'make a readme for my repo' is an explicit trigger phrase in the description"
+  },
+  {
+    "query": "the readme is terrible, fix it — too much marketing, no real examples",
+    "should_trigger": true,
+    "notes": "'the readme is terrible, fix it' is an explicit trigger phrase in the description"
+  },
+  {
+    "query": "I need docs for this package, it's a Python data validation library",
+    "should_trigger": true,
+    "notes": "'I need docs for this package' is an explicit trigger phrase in the description"
+  },
+  {
+    "query": "can you write a getting started doc for my open source Node library?",
+    "should_trigger": true,
+    "notes": "'getting started doc' is listed as a trigger in the description"
+  },
+  {
+    "query": "Here's my package.json — can you write documentation for this project so people know how to install and use it?",
+    "should_trigger": true,
+    "notes": "User shares repo artifact and asks for documentation — covered by description"
+  },
+  {
+    "query": "generate a README.md for this Go microservice",
+    "should_trigger": true,
+    "notes": "Explicit 'generate' + 'README.md' — squarely in scope"
+  },
+  {
+    "query": "my readme is three years out of date, please rewrite it from scratch",
+    "should_trigger": true,
+    "notes": "'rewrite a README' is an explicit trigger verb in the description"
+  },
+  {
+    "query": "I want a proper GitHub landing page for this project — something that makes people want to use it",
+    "should_trigger": true,
+    "notes": "'GitHub landing page' is an explicit trigger in the description"
+  },
+  {
+    "query": "update the CHANGELOG, we just shipped v1.3.0",
+    "should_trigger": false,
+    "notes": "CHANGELOG update — explicitly excluded in description (changelogs)"
+  },
+  {
+    "query": "write a blog post about how I built this microservices architecture",
+    "should_trigger": false,
+    "notes": "Blog post — explicitly excluded in description (blog posts)"
+  },
+  {
+    "query": "create a CONTRIBUTING.md so people know how to open pull requests to this repo",
+    "should_trigger": false,
+    "notes": "CONTRIBUTING.md — markdown file about the project, but not a README; different purpose"
+  },
+  {
+    "query": "I need a design doc for the new auth system — requirements, constraints, and proposed approach",
+    "should_trigger": false,
+    "notes": "Design doc — explicitly excluded in description (design docs)"
+  },
+  {
+    "query": "add JSDoc comments to all the exported functions in src/api.ts",
+    "should_trigger": false,
+    "notes": "Inline code documentation — 'docs' keyword shared but this is source-level, not a README"
+  },
+  {
+    "query": "write release notes for v2.0 summarising what changed since v1.x",
+    "should_trigger": false,
+    "notes": "Release notes — documentation adjacent but explicitly excluded (changelogs); not a README"
+  },
+  {
+    "query": "can you explain what this codebase does? I just inherited it and have no idea",
+    "should_trigger": false,
+    "notes": "Explanation request — no write intent; user wants understanding, not a README file"
+  },
+  {
+    "query": "generate OpenAPI documentation from the Express routes in routes/api.js",
+    "should_trigger": false,
+    "notes": "API spec generation — 'generate' + 'documentation' keywords shared, but output is an OpenAPI spec not a README"
+  },
+  {
+    "query": "add a CODE_OF_CONDUCT.md and a SECURITY.md to the repo",
+    "should_trigger": false,
+    "notes": "Other governance markdown files — project docs but neither is a README"
+  },
+  {
+    "query": "I want a detailed wiki with separate pages covering architecture, deployment, and the full API reference",
+    "should_trigger": false,
+    "notes": "Wiki / multi-page docs site — documentation intent but explicitly a different artifact than a README"
+  }
+]


### PR DESCRIPTION
## What

Adds the `handoff` skill — saves or loads a structured JSON snapshot of session state (schema v2.0.0) so work can resume cleanly in a new session or be delegated to a sub-agent.

## Why

`/compact` is lossy and exhibits recency bias. A handoff snapshot forces every field to be explicit — goal, decisions, completed steps, pending steps, constraints, discovered issues, modified files — so nothing is silently dropped across context boundaries.

## Type of Change

- [x] New skill

## Skill Checklist

- [x] `SKILL.md` has valid YAML frontmatter (`name`, `description`, `allowed-tools`)
- [x] `name` is lowercase-hyphenated and matches the directory name
- [x] `description` is written in third person with trigger words
- [x] Reference files are in `references/` (one level deep)
- [x] `SKILL.md` is under 500 lines
- [x] No secrets, credentials, or PII committed
- [x] `.claude-plugin/marketplace.json` updated (if new skill)
- [x] `README.md` skills table updated (if new skill)

## Testing

- [x] Tested locally by invoking the skill with a realistic prompt
- [x] Verified the skill activates correctly (not confused with another skill)
- [x] 3 functional evals passing (23/23 expectations) — create-default-path, create-explicit-filename, resume-from-file
- [x] Trigger accuracy: ~50% (known limitation — skill is primarily explicit slash-command invocation, same characteristic as workflow skills; natural language triggers work in interactive sessions)

Closes #14