### PR TITLE
fix: use metadata.internal: true to suppress workflow skills from npx skills add

### DIFF
--- a/.claude/skills/conventions/SKILL.md
+++ b/.claude/skills/conventions/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: conventions
-publish: false
+metadata:
+  internal: true
 description: >
   Defines the commit message, branch naming, pull request, and release note
   conventions for the ai-agent-skills repository. Make sure to load this skill

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: release
-publish: false
+metadata:
+  internal: true
 description: >
   Ships completed work in the ai-agent-skills repository. Two phases depending on
   context: WRAP UP (on a feature branch with committed work — updates CHANGELOG,

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: start
-publish: false
+metadata:
+  internal: true
 description: >
   Begins a new piece of work in the ai-agent-skills repository. Two modes: EXISTING
   ISSUE (user provides a GitHub issue number or URL — fetches it, cuts the correct

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **marketplace** — Replace ineffective `publish: false` frontmatter with `metadata.internal: true` on workflow skills (`start`, `release`, `conventions`) — the only field the `skills` CLI (v1.5.1) actually checks to suppress discovery. ([#19](https://github.com/psenger/ai-agent-skills/issues/19))
+
 ## [1.1.1] - 2026-04-25
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Replace `publish: false` with `metadata.internal: true` on all three workflow skills (`start`, `release`, `conventions`)
- Update CHANGELOG with correct fix description

## Issue
Closes #19

## Why
The `skills` CLI v1.5.1 ignores `publish: false` and `.skillignore` entirely. The only field the parser actually checks is `metadata.internal` — skills with this set to `true` are skipped unless `--include-internal` is passed explicitly.

## Test plan
- [ ] `npx skills add psenger/ai-agent-skills` no longer lists `start`, `release`, or `conventions`
- [ ] Public skills still appear correctly