### PR TITLE
feat(agent-os): add agent-os-assist and agent-os-profile-critique skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,6 +39,18 @@
       "source": "./skills/handoff",
       "description": "Make sure to use this skill whenever the user types /handoff (with or without a filename argument), says \"handoff\", \"save state\", \"context rot\", \"save session\", \"create a handoff\", \"I need a clean start\", wants to snapshot progress before clearing context or switching sessions, is approaching the context limit (300–400k tokens), or wants to delegate the current session state to another agent. Also invoke for RESUME mode: when the user says \"load handoff\", \"resume from [file]\", \"continue where we left off\", \"pick up where I left off\", \"load the handoff at [path]\", references a .claude/handoffs/ file path, or says there is a handoff file from a prior session.",
       "version": "1.0.0"
+    },
+    {
+      "name": "agent-os-assist",
+      "source": "./skills/agent-os-assist",
+      "description": "Agent OS reference for installation, slash commands, profiles, and ticket-to-spec workflows. This skill holds reference documentation not in Claude's training; always invoke it before answering any Agent OS question.",
+      "version": "1.0.0"
+    },
+    {
+      "name": "agent-os-profile-critique",
+      "source": "./skills/agent-os-profile-critique",
+      "description": "Provides the audit checklists, severity criteria (blocking/warning/suggestion), and artifact patterns needed to properly review Agent OS profiles and standards.",
+      "version": "1.0.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **agent-os-assist** — New skill for Agent OS v3 installation, slash commands, profiles, and ticket-to-spec workflows; includes trigger evals and workspace infrastructure. ([#21](https://github.com/psenger/ai-agent-skills/issues/21))
+- **agent-os-profile-critique** — New skill that audits and critiques Agent OS v3 profiles and standards with severity-tagged findings (blocking, warning, suggestion); includes review checklists and trigger evals. ([#21](https://github.com/psenger/ai-agent-skills/issues/21))
+
 ## [1.1.2] - 2026-04-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Think of it as a playbook: you define the process once, and the agent follows it
 | **[review-api-design](skills/review-api-design/)** | `/review-api-design` | Reviews REST API designs during the planning phase against security, resilience, design, and operational best practices — produces structured findings with severity levels, source citations, and a readiness assessment |
 | **[create-a-skill](skills/create-a-skill/)** | `/create-a-skill` | Create new agent skills from scratch, modify and improve existing skills, and measure skill performance — interviews the user, drafts SKILL.md with bundled resources, runs evals, benchmarks, iterates on feedback, optimises description triggering, and packages distributable `.skill` files |
 | **[handoff](skills/handoff/)** | `/handoff` | Saves or loads a structured JSON snapshot of session state so work can resume cleanly in a new session or be delegated to a sub-agent — better than `/compact` because the schema forces every field to be explicit |
+| **[agent-os-assist](skills/agent-os-assist/)** | `/agent-os-assist` | Agent OS v3 reference for installation, slash commands, profiles, and ticket-to-spec workflows — holds version-specific documentation not in Claude's training and routes pre-3.0 installs to the migration reference |
+| **[agent-os-profile-critique](skills/agent-os-profile-critique/)** | `/agent-os-profile-critique` | Audits and critiques Agent OS v3 profiles and standards — produces severity-tagged findings (blocking, warning, suggestion) with concrete fix recommendations |
 
 ### vault-scribe
 
@@ -531,6 +533,85 @@ Captures the complete state of your current session to a structured JSON snapsho
 /handoff                          # save to .claude/handoffs/<timestamp>-<slug>.json
 /handoff auth-refactor.json       # save to explicit path
 /handoff load auth-refactor.json  # resume from file
+```
+
+### agent-os-assist
+
+Your Agent OS v3 reference. Covers installation, slash commands, profiles, standards, and ticket-to-spec workflows — with the version-specific documentation not in Claude's training data.
+
+**Use cases:**
+
+- Bootstrap a fresh Agent OS v3 install end-to-end
+- Turn a Jira or GitHub ticket into a `/shape-spec` run
+- Configure profile inheritance in `~/agent-os/config.yml`
+- Write your first standard after installing Agent OS
+- Recover a broken spec without losing conversation history
+- Migrate from v2 artifacts to v3 conventions
+
+```
+/agent-os-assist
+```
+
+Or trigger it naturally:
+
+```
+"How do I install Agent OS?"
+"Turn this GitHub issue into an Agent OS spec"
+"What should be in ~/agent-os/config.yml?"
+"I just installed agent-os, where do I start?"
+"My spec is wrong — how do I recover without losing history?"
+```
+
+```
+agent-os-assist/
+├── SKILL.md                          Routing table + workflow overview
+└── references/
+    ├── getting-started.md            Bootstrap and onboarding workflows
+    ├── installation.md               Install and scaffold steps
+    ├── commands.md                   Slash command reference
+    ├── profiles.md                   Profile structure and inheritance
+    ├── standards.md                  Writing and managing standards
+    ├── standards-vs-skills.md        When to use a standard vs a skill
+    ├── file-structure.md             v3 directory layout
+    └── v2-vs-v3.md                   Migration reference and v2 artifact flags
+```
+
+### agent-os-profile-critique
+
+Your Agent OS profile audit assistant. Reviews profiles and standards files against v3 conventions and produces severity-tagged findings with concrete rewrite suggestions.
+
+**Severity levels:**
+
+| Level | Meaning |
+|---|---|
+| Blocking | Must fix before the profile is usable |
+| Warning | Should fix; degrades AI effectiveness or causes drift |
+| Suggestion | Improves clarity, context-window efficiency, or maintainability |
+
+```
+/agent-os-profile-critique
+```
+
+Or trigger it naturally:
+
+```
+"Audit my Agent OS profile"
+"Review this standard — is it any good?"
+"Critique my agent-os setup"
+"What's wrong with this standards file?"
+"Validate my profile against v3 conventions"
+```
+
+```
+agent-os-profile-critique/
+├── SKILL.md                          Routing table + audit workflow
+└── references/
+    ├── review-checklists.md          Severity-tagged audit checklists
+    ├── standards.md                  Standards quality criteria
+    ├── file-structure.md             v3 directory layout reference
+    ├── profiles.md                   Profile conventions
+    ├── standards-vs-skills.md        Standards vs skills decision guide
+    └── v2-vs-v3.md                   v2 artifact detection patterns
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -562,6 +562,8 @@ Or trigger it naturally:
 "My spec is wrong — how do I recover without losing history?"
 ```
 
+**Note:** This skill is difficult to trigger reliably from natural language alone — invoke it explicitly with `/agent-os-assist` for best results.
+
 ```
 agent-os-assist/
 ├── SKILL.md                          Routing table + workflow overview
@@ -601,6 +603,8 @@ Or trigger it naturally:
 "What's wrong with this standards file?"
 "Validate my profile against v3 conventions"
 ```
+
+**Note:** This skill is difficult to trigger reliably from natural language alone — invoke it explicitly with `/agent-os-profile-critique` for best results.
 
 ```
 agent-os-profile-critique/

--- a/skills/agent-os-assist/.skillignore
+++ b/skills/agent-os-assist/.skillignore
@@ -1,0 +1,1 @@
+.workspace/

--- a/skills/agent-os-assist/.workspace/EVAL-REPORT.md
+++ b/skills/agent-os-assist/.workspace/EVAL-REPORT.md
@@ -1,0 +1,125 @@
+# Eval Report — agent-os-assist
+
+This document describes the eval suite for the `agent-os-assist` skill, what each test
+verifies, and where to record results after a run. Results sections are stubbed until
+the suite is executed.
+
+## Files under test
+
+- `skills/agent-os-assist/SKILL.md`
+- `skills/agent-os-assist/references/*.md` — 8 reference files
+- `skills/agent-os-assist/.workspace/evals/trigger-evals.json` — 20 queries
+- `skills/agent-os-assist/.workspace/evals/evals.json` — 2 functional cases
+
+## Trigger evals
+
+Tests whether the skill description activates on the right prompts and stays quiet on
+the wrong ones. Target: 95% (19/20).
+
+Run (from repo root):
+```bash
+bash skills/agent-os-assist/.workspace/run-trigger-eval.sh
+```
+
+### Should-trigger queries (10)
+
+| # | Query | What it verifies |
+|---|---|---|
+| 1 | How do I turn JIRA-1234 ticket into an Agent OS spec | Ticket-to-spec, ticket key reference |
+| 2 | How do I turn this ticket https://mycompany.atlassian.net/browse/PROJ-1234 into an Agent OS spec | Ticket-to-spec, Jira URL reference |
+| 3 | How do I turn GitHub issue #42 into an Agent OS spec | Ticket-to-spec, GitHub issue number reference |
+| 4 | How do I turn this issue https://github.com/myorg/myrepo/issues/42 into a spec | Ticket-to-spec, GitHub issue URL reference |
+| 5 | Should I commit the agent-os directory in my project to git? | Version control question about agent-os project directory |
+| 6 | I dont know what to do now that I installed agent-os | Post-install onboarding, user-supplied phrasing |
+| 7 | I just installed agent-os and need to write my first standard. Where do I start? | Post-install onboarding plus first standard authoring |
+| 8 | How do I make a new corporate or enterprise standard? | Authoring a new standard at org scope |
+| 9 | What should be in ~/agent-os/config.yml for inheritance to work? | config.yml plus ~/agent-os/ path activates |
+| 10 | My Agent OS spec for the auth feature is wrong. How do I recover without losing history? | Spec recovery use case activates |
+
+### Should-not-trigger queries (10)
+
+These are tricky near-misses that distinguish this skill from generic project work.
+
+| # | Query | Why it must NOT trigger |
+|---|---|---|
+| 1 | Set up a new Node.js project structure with Express and TypeScript | Generic scaffolding, no Agent OS context |
+| 2 | Audit my package.json for outdated dependencies and security issues | "Audit" keyword present but unrelated to Agent OS |
+| 3 | Help me write a coding standard document for our team's React work | "Standard" keyword but no Agent OS context |
+| 4 | How do I configure my .eslintrc.yml for monorepo workspaces? | Config-file question for an unrelated tool |
+| 5 | Review this REST API design and tell me where the security holes are | "Review" keyword but API-design domain |
+| 6 | What's the best operating system for running coding agents locally? | Literal "operating system" near-miss for "agent os" |
+| 7 | Create a config.yml for my GitHub Actions deployment workflow | config.yml in unrelated product context |
+| 8 | Write me an OpenAPI spec for the /users endpoint | "Spec" keyword but OpenAPI, not /shape-spec |
+| 9 | How do I customize my GitHub profile README? | "Profile" keyword in unrelated context |
+| 10 | Set up a CI/CD pipeline spec for our staging deployment | "Spec" plus "set up" but DevOps domain |
+
+### Trigger eval results
+
+**Run 2026-05-10 — isolated, no competing skills**
+
+- **Score:** 10 / 20
+- **Precision:** 100%
+- **Recall:** 7%
+- **Accuracy:** 53%
+- **False negatives (should-trigger, did not fire):**
+  - How do I turn jira ticket into an Agent OS spec
+  - How do I turn this issue https://github.com/myorg/myrepo/issues/42 into a spec
+  - How do I turn this ticket https://mycompany.atlassian.net/browse/PROJ-1234 into an Agent OS spec
+  - How do I turn GitHub issue #42 into an Agent OS spec
+  - Should I commit the agent-os directory in my project to git?
+  - I dont know what to do now that I installed agent-os
+  - I just installed agent-os and need to write my first standard. Where do I start?
+  - How do I make a new corporate or enterprise standard?
+  - What should be in ~/agent-os/config.yml for inheritance to work?
+  - My Agent OS spec for the auth feature is wrong. How do I recover without losing history?
+- **False positives:** none
+- **Decision:** _update after review_
+
+## Functional evals
+
+Tests whether the skill produces correct output. Two cases.
+
+### Case 1 — `explain-inheritance-uses-correct-file`
+
+**Prompt:** How does profile inheritance work in Agent OS? Where do I configure that
+one profile inherits from another?
+
+**What it verifies:**
+- The answer names `~/agent-os/config.yml` as the inheritance file.
+- The answer references the `inherits_from` field.
+- The answer states that child overrides parent on filename collision.
+- The answer does NOT recommend `profile-config.yml`.
+- The answer flags `profile-config.yml` as a v2 artifact if it surfaces.
+
+### Case 2 — `recover-broken-spec-without-losing-history`
+
+**Prompt:** I ran `/shape-spec` on a feature an hour ago and the spec it produced is
+wrong. I don't want to throw away the conversation history. How do I recover?
+
+**What it verifies:**
+- The answer distinguishes shape, plan, standards, and drift as failure layers.
+- The answer recommends preserving history rather than starting over.
+- The answer suggests editing the spec file directly or re-running `/shape-spec`
+  with refined inputs.
+- The answer does not invent commands or flags that are not in
+  `references/commands.md`.
+
+### Functional eval results
+
+_Pending first run._
+
+## Acceptance criteria coverage
+
+| Criterion | Verified by |
+|---|---|
+| Skill loads in Claude Code without validation errors | Manual: `ls`, frontmatter check |
+| Description triggers reliably on assist/help/install/ticket queries | Trigger evals (target 95%) |
+| Skill does NOT trigger on profile-critique or generic queries | Trigger evals (should-not-trigger) |
+| Skill names ~/agent-os/config.yml for inheritance | Functional case 1 |
+| Skill does not invent commands or flags | Functional case 2 |
+| No em-dashes; imperative voice throughout | Manual: `grep -n '—'` |
+
+## How to update this report
+
+After each run, replace the corresponding "_Pending first run._" block with the
+actual numbers and observations.

--- a/skills/agent-os-assist/.workspace/README.md
+++ b/skills/agent-os-assist/.workspace/README.md
@@ -1,0 +1,116 @@
+# Trigger Eval — agent-os-assist
+
+How to run the trigger eval suite and read the results.
+
+## Quick start
+
+Run this from the repo root:
+
+```bash
+bash skills/agent-os-assist/.workspace/run-trigger-eval.sh
+```
+
+The script handles everything: isolating the environment, smoke-testing auth, running the eval, and restoring your original `~/.claude` when done.
+
+## What the script does
+
+1. Moves `~/.claude` to `~/.claude-back` (atomic rename).
+2. Builds a minimal `~/.claude` containing only `sessions/`, `config/`, and `statsig/` — no competing skills.
+3. Smoke-tests auth with `claude -p 'say: ok'`. Exits early if auth fails.
+4. Runs one eval pass with no train/test holdout.
+5. Prints a summary and updates `EVAL-REPORT.md` with the latest results.
+6. Restores `~/.claude` from `~/.claude-back` — always, even on error or Ctrl-C.
+
+**If the script crashes mid-run** and leaves `~/.claude-back` behind, check that `~/.claude` looks correct, then remove `~/.claude-back` manually before retrying.
+
+## Reading the output
+
+The terminal summary looks like this:
+
+```
+ Score:     13/13
+ Precision: 100%  (of triggers, how many were correct)
+ Recall:    80%   (of positives, how many fired)
+ Accuracy:  92%
+
+ SHOULD TRIGGER:
+  [PASS] 3/3  How do I turn jira ticket into an Agent OS spec
+  [FAIL] 1/3  I dont know what to do now that I installed agent-os
+  ...
+
+ SHOULD NOT TRIGGER:
+  [PASS] 0/3  Set up a new Node.js project structure with Express and TypeScript
+  ...
+
+ Results saved to: .workspace/evals/results/2026-05-10_153012/results.json
+```
+
+- **Precision** — of all the times the skill triggered, what fraction was correct. False positives hurt this.
+- **Recall** — of all the queries that should have triggered the skill, what fraction actually did. False negatives hurt this.
+- **Accuracy** — overall correct rate across both positive and negative queries.
+
+Raw results are saved as JSON under `.workspace/evals/results/<timestamp>/results.json`.
+
+## Advanced: run the eval loop directly
+
+For more control — more iterations, different models, holdout testing — call the underlying script directly. Run from the repo root:
+
+```bash
+PYTHONPATH="$HOME/.claude/skills/create-a-skill" python3 -m scripts.run_loop \
+  --eval-set skills/agent-os-assist/.workspace/evals/trigger-evals.json \
+  --skill-path skills/agent-os-assist \
+  --model claude-sonnet-4-6 \
+  --max-iterations 5 \
+  --holdout 0.4 \
+  --verbose
+```
+
+### Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `--eval-set` | required | Path to the trigger eval JSON file. |
+| `--skill-path` | required | Path to the skill directory (must contain `SKILL.md`). |
+| `--model` | required | Claude model ID to use for running queries and generating description improvements. |
+| `--max-iterations` | `5` | How many improve-and-retest cycles to run before stopping. Set to `1` for a diagnostic pass with no improvement. |
+| `--holdout` | `0.4` | Fraction of the eval set to reserve as a held-out test set. The improvement loop only sees the training split. Set to `0` to use all queries for training (no test set). |
+| `--runs-per-query` | `3` | How many times each query is run. The trigger rate across all runs determines pass/fail. Higher values reduce flakiness but take longer. |
+| `--trigger-threshold` | `0.5` | Minimum trigger rate to count a query as "triggered". At `0.5` with 3 runs, 2 out of 3 must trigger. |
+| `--num-workers` | `10` | Number of parallel `claude -p` processes. Reduce if you hit rate limits. |
+| `--timeout` | `30` | Seconds to wait per query before marking it as not triggered. |
+| `--description` | none | Override the description from `SKILL.md` with a specific string to test. Useful for A/B testing a candidate description without editing the file. |
+| `--report` | `auto` | Where to write the HTML report. `auto` writes to a temp file and opens it in your browser. `none` disables the report. Any other value is treated as a file path. |
+| `--results-dir` | none | Directory to save a timestamped run folder containing `results.json`, `report.html`, and improvement logs. |
+| `--verbose` | off | Print per-query results and progress to stderr while running. |
+
+### The improvement loop
+
+When `--max-iterations` is greater than 1, the loop:
+
+1. Runs all eval queries against the current description.
+2. Identifies which queries failed.
+3. Asks the model to propose an improved description.
+4. Re-runs the eval with the new description.
+5. Repeats until all train queries pass or max iterations is reached.
+
+The best description (by test score if a holdout is set, otherwise by train score) is printed in the JSON output as `best_description`. To apply it, copy that value into the `description:` field in `SKILL.md`.
+
+## Eval query file
+
+The eval queries live at:
+
+```
+.workspace/evals/trigger-evals.json
+```
+
+Each entry has three fields:
+
+```json
+{
+  "query": "the user prompt to test",
+  "should_trigger": true,
+  "notes": "why this query was included"
+}
+```
+
+Edit this file to add, remove, or adjust queries. After editing, re-run the shell script to see the updated results.

--- a/skills/agent-os-assist/.workspace/evals/evals.json
+++ b/skills/agent-os-assist/.workspace/evals/evals.json
@@ -1,0 +1,32 @@
+{
+  "skill_name": "agent-os-assist",
+  "evals": [
+    {
+      "id": 1,
+      "name": "explain-inheritance-uses-correct-file",
+      "prompt": "How does profile inheritance work in Agent OS? Where do I configure that one profile inherits from another?",
+      "expected_output": "Explains that inheritance is configured in ~/agent-os/config.yml at the base install, not in any per-profile file. Names the inherits_from field. States that child profile files override parent files when filenames collide. Explicitly warns against using profile-config.yml because that is a v2 artifact.",
+      "files": [],
+      "expectations": [
+        "The answer names ~/agent-os/config.yml as the file where inheritance is configured",
+        "The answer references the inherits_from field or equivalent inheritance directive",
+        "The answer states that child overrides parent when filenames collide",
+        "The answer does NOT recommend using profile-config.yml",
+        "The answer flags profile-config.yml as a v2 artifact if it appears in the user's mental model"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "recover-broken-spec-without-losing-history",
+      "prompt": "I ran /shape-spec on a feature an hour ago and the spec it produced is wrong — wrong scope, missing constraints. I don't want to throw away the conversation history. How do I recover?",
+      "expected_output": "Diagnoses which layer is broken (shape vs. plan vs. standards vs. drift). Recommends a recovery path that preserves history: edit the spec file directly or re-run /shape-spec with refined input rather than discarding the session. Reads references/getting-started.md or references/commands.md before answering.",
+      "files": [],
+      "expectations": [
+        "The answer distinguishes between shape, plan, standards, and drift as possible failure layers",
+        "The answer recommends preserving history rather than starting over",
+        "The answer suggests editing the spec file directly or re-running /shape-spec with refined inputs",
+        "The answer does not invent commands or flags not listed in references/commands.md"
+      ]
+    }
+  ]
+}

--- a/skills/agent-os-assist/.workspace/evals/results/2026-05-10_203007/results.json
+++ b/skills/agent-os-assist/.workspace/evals/results/2026-05-10_203007/results.json
@@ -1,0 +1,353 @@
+{
+  "exit_reason": "max_iterations (1)",
+  "original_description": "Agent OS v3 reference for installation, slash commands, profiles, and ticket-to-spec workflows. This skill holds version-specific documentation not in Claude's training; always invoke it before answering any Agent OS question - v3 changed file layouts, removed subagents, and retired commands that still appear in old guides. Invoke whenever the user message contains any of: \"agent-os\", \"Agent OS\", \"agent os\", \"~/agent-os\", \"/agent-os/\", \"shape-spec\", \"inject-standards\", \"discover-standards\", \"index-standards\", \"plan-product\". Also invoke when the user asks to: turn a Jira ticket, GitHub issue number, or GitHub issue URL into a spec or plan; set up corporate or enterprise coding standards; commit or version-control an agent-os folder; configure profile inheritance in config.yml; write their first standard after installing agent-os; or recover a broken spec without losing history.",
+  "best_description": "Agent OS v3 reference for installation, slash commands, profiles, and ticket-to-spec workflows. This skill holds version-specific documentation not in Claude's training; always invoke it before answering any Agent OS question - v3 changed file layouts, removed subagents, and retired commands that still appear in old guides. Invoke whenever the user message contains any of: \"agent-os\", \"Agent OS\", \"agent os\", \"~/agent-os\", \"/agent-os/\", \"shape-spec\", \"inject-standards\", \"discover-standards\", \"index-standards\", \"plan-product\". Also invoke when the user asks to: turn a Jira ticket, GitHub issue number, or GitHub issue URL into a spec or plan; set up corporate or enterprise coding standards; commit or version-control an agent-os folder; configure profile inheritance in config.yml; write their first standard after installing agent-os; or recover a broken spec without losing history.",
+  "best_score": "10/20",
+  "best_train_score": "10/20",
+  "best_test_score": null,
+  "final_description": "Agent OS v3 reference for installation, slash commands, profiles, and ticket-to-spec workflows. This skill holds version-specific documentation not in Claude's training; always invoke it before answering any Agent OS question - v3 changed file layouts, removed subagents, and retired commands that still appear in old guides. Invoke whenever the user message contains any of: \"agent-os\", \"Agent OS\", \"agent os\", \"~/agent-os\", \"/agent-os/\", \"shape-spec\", \"inject-standards\", \"discover-standards\", \"index-standards\", \"plan-product\". Also invoke when the user asks to: turn a Jira ticket, GitHub issue number, or GitHub issue URL into a spec or plan; set up corporate or enterprise coding standards; commit or version-control an agent-os folder; configure profile inheritance in config.yml; write their first standard after installing agent-os; or recover a broken spec without losing history.",
+  "iterations_run": 1,
+  "holdout": 0.0,
+  "train_size": 20,
+  "test_size": 0,
+  "history": [
+    {
+      "iteration": 1,
+      "description": "Agent OS v3 reference for installation, slash commands, profiles, and ticket-to-spec workflows. This skill holds version-specific documentation not in Claude's training; always invoke it before answering any Agent OS question - v3 changed file layouts, removed subagents, and retired commands that still appear in old guides. Invoke whenever the user message contains any of: \"agent-os\", \"Agent OS\", \"agent os\", \"~/agent-os\", \"/agent-os/\", \"shape-spec\", \"inject-standards\", \"discover-standards\", \"index-standards\", \"plan-product\". Also invoke when the user asks to: turn a Jira ticket, GitHub issue number, or GitHub issue URL into a spec or plan; set up corporate or enterprise coding standards; commit or version-control an agent-os folder; configure profile inheritance in config.yml; write their first standard after installing agent-os; or recover a broken spec without losing history.",
+      "train_passed": 10,
+      "train_failed": 10,
+      "train_total": 20,
+      "train_results": [
+        {
+          "query": "How do I turn jira ticket into an Agent OS spec",
+          "should_trigger": true,
+          "trigger_rate": 0.3333333333333333,
+          "triggers": 1,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "How do I turn this issue https://github.com/myorg/myrepo/issues/42 into a spec",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "How do I turn this ticket https://mycompany.atlassian.net/browse/PROJ-1234 into an Agent OS spec",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "How do I turn GitHub issue #42 into an Agent OS spec",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "Should I commit the agent-os directory in my project to git?",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "I dont know what to do now that I installed agent-os",
+          "should_trigger": true,
+          "trigger_rate": 0.3333333333333333,
+          "triggers": 1,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "I just installed agent-os and need to write my first standard. Where do I start?",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "How do I make a new corporate or enterprise standard?",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "What should be in ~/agent-os/config.yml for inheritance to work?",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "My Agent OS spec for the auth feature is wrong. How do I recover without losing history?",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "Set up a new Node.js project structure with Express and TypeScript",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Audit my package.json for outdated dependencies and security issues",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Help me write a coding standard document for our team's React work",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Review this REST API design and tell me where the security holes are",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "What's the best operating system for running coding agents locally?",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Create a config.yml for my GitHub Actions deployment workflow",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "How do I configure my .eslintrc.yml for monorepo workspaces?",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Write me an OpenAPI spec for the /users endpoint",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Set up a CI/CD pipeline spec for our staging deployment",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "How do I customize my GitHub profile README?",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        }
+      ],
+      "test_passed": null,
+      "test_failed": null,
+      "test_total": null,
+      "test_results": null,
+      "passed": 10,
+      "failed": 10,
+      "total": 20,
+      "results": [
+        {
+          "query": "How do I turn jira ticket into an Agent OS spec",
+          "should_trigger": true,
+          "trigger_rate": 0.3333333333333333,
+          "triggers": 1,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "How do I turn this issue https://github.com/myorg/myrepo/issues/42 into a spec",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "How do I turn this ticket https://mycompany.atlassian.net/browse/PROJ-1234 into an Agent OS spec",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "How do I turn GitHub issue #42 into an Agent OS spec",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "Should I commit the agent-os directory in my project to git?",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "I dont know what to do now that I installed agent-os",
+          "should_trigger": true,
+          "trigger_rate": 0.3333333333333333,
+          "triggers": 1,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "I just installed agent-os and need to write my first standard. Where do I start?",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "How do I make a new corporate or enterprise standard?",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "What should be in ~/agent-os/config.yml for inheritance to work?",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "My Agent OS spec for the auth feature is wrong. How do I recover without losing history?",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "Set up a new Node.js project structure with Express and TypeScript",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Audit my package.json for outdated dependencies and security issues",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Help me write a coding standard document for our team's React work",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Review this REST API design and tell me where the security holes are",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "What's the best operating system for running coding agents locally?",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Create a config.yml for my GitHub Actions deployment workflow",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "How do I configure my .eslintrc.yml for monorepo workspaces?",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Write me an OpenAPI spec for the /users endpoint",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Set up a CI/CD pipeline spec for our staging deployment",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "How do I customize my GitHub profile README?",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        }
+      ]
+    }
+  ]
+}

--- a/skills/agent-os-assist/.workspace/evals/trigger-evals.json
+++ b/skills/agent-os-assist/.workspace/evals/trigger-evals.json
@@ -1,0 +1,102 @@
+[
+  {
+    "query": "How do I turn jira ticket into an Agent OS spec",
+    "should_trigger": true,
+    "notes": "Ticket-to-spec workflow, ticket key reference"
+  },
+  {
+    "query": "How do I turn this ticket https://mycompany.atlassian.net/browse/PROJ-1234 into an Agent OS spec",
+    "should_trigger": true,
+    "notes": "Ticket-to-spec workflow, Jira URL reference"
+  },
+  {
+    "query": "How do I turn GitHub issue #42 into an Agent OS spec",
+    "should_trigger": true,
+    "notes": "Ticket-to-spec workflow, GitHub issue number reference"
+  },
+  {
+    "query": "How do I turn this issue https://github.com/myorg/myrepo/issues/42 into a spec",
+    "should_trigger": true,
+    "notes": "Ticket-to-spec workflow, GitHub issue URL reference"
+  },
+  {
+    "query": "Should I commit the agent-os directory in my project to git?",
+    "should_trigger": true,
+    "notes": "Version control question about agent-os project directory"
+  },
+  {
+    "query": "I dont know what to do now that I installed agent-os",
+    "should_trigger": true,
+    "notes": "Post-install onboarding, exact user phrasing"
+  },
+  {
+    "query": "I just installed agent-os and need to write my first standard. Where do I start?",
+    "should_trigger": true,
+    "notes": "Post-install onboarding plus authoring first standard"
+  },
+  {
+    "query": "How do I make a new corporate or enterprise standard?",
+    "should_trigger": true,
+    "notes": "Authoring a new standard at org scope, exact user phrasing"
+  },
+  {
+    "query": "What should be in ~/agent-os/config.yml for inheritance to work?",
+    "should_trigger": true,
+    "notes": "config.yml + agent-os path"
+  },
+  {
+    "query": "My Agent OS spec for the auth feature is wrong. How do I recover without losing history?",
+    "should_trigger": true,
+    "notes": "Spec recovery, no slash command collision"
+  },
+  {
+    "query": "Set up a new Node.js project structure with Express and TypeScript",
+    "should_trigger": false,
+    "notes": "General project scaffolding, no Agent OS context"
+  },
+  {
+    "query": "Audit my package.json for outdated dependencies and security issues",
+    "should_trigger": false,
+    "notes": "Audit keyword but unrelated to Agent OS"
+  },
+  {
+    "query": "Help me write a coding standard document for our team's React work",
+    "should_trigger": false,
+    "notes": "Standard keyword but no Agent OS context, generic team doc"
+  },
+  {
+    "query": "How do I configure my .eslintrc.yml for monorepo workspaces?",
+    "should_trigger": false,
+    "notes": "config file question but unrelated tool"
+  },
+  {
+    "query": "Review this REST API design and tell me where the security holes are",
+    "should_trigger": false,
+    "notes": "Review keyword but API design domain, not Agent OS"
+  },
+  {
+    "query": "What's the best operating system for running coding agents locally?",
+    "should_trigger": false,
+    "notes": "Literal 'operating system' near-miss for 'agent os'"
+  },
+  {
+    "query": "Create a config.yml for my GitHub Actions deployment workflow",
+    "should_trigger": false,
+    "notes": "config.yml near-miss, wrong product context"
+  },
+  {
+    "query": "Write me an OpenAPI spec for the /users endpoint",
+    "should_trigger": false,
+    "notes": "spec keyword but OpenAPI, not /shape-spec"
+  },
+  {
+    "query": "How do I customize my GitHub profile README?",
+    "should_trigger": false,
+    "notes": "profile keyword in unrelated context"
+  },
+  {
+    "query": "Set up a CI/CD pipeline spec for our staging deployment",
+    "should_trigger": false,
+    "notes": "spec + setup keywords but DevOps domain, not Agent OS"
+  }
+]

--- a/skills/agent-os-assist/.workspace/run-trigger-eval.sh
+++ b/skills/agent-os-assist/.workspace/run-trigger-eval.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Isolated trigger eval for agent-os-expert.
+#
+# 1. Moves ~/.claude to ~/.claude-back (atomic rename)
+# 2. Builds a minimal ~/.claude with only auth files
+# 3. Smoke-tests auth before wasting time on a broken run
+# 4. Runs the trigger eval
+# 5. Restores ~/.claude — always, even on error or ctrl-c
+set -euo pipefail
+
+CLAUDE_DIR="$HOME/.claude"
+BACKUP_DIR="$HOME/.claude-back"
+SCRIPT_DIR="$HOME/.claude-back/skills/create-a-skill"
+
+WORKSPACE_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_EVAL_SET="$WORKSPACE_DIR/evals/trigger-evals.json"
+SKILL_PATH="$(cd "$WORKSPACE_DIR/.." && pwd)"
+RESULTS_DIR="$WORKSPACE_DIR/evals/results"
+
+# ── restore ────────────────────────────────────────────────────────────────────
+
+restore() {
+    echo ""
+    echo "==> Restoring ~/.claude ..."
+    rm -rf "$CLAUDE_DIR"
+    mv "$BACKUP_DIR" "$CLAUDE_DIR"
+    echo "    Done."
+}
+
+trap restore EXIT
+
+# ── guard: nothing left behind from a previous crashed run ────────────────────
+
+if [ -d "$BACKUP_DIR" ]; then
+    echo "ERROR: $BACKUP_DIR already exists — a previous run may not have restored cleanly."
+    echo "       If ~/.claude looks correct, remove $BACKUP_DIR and retry."
+    exit 1
+fi
+
+# ── move ~/.claude aside ──────────────────────────────────────────────────────
+
+echo "==> Moving ~/.claude to ~/.claude-back ..."
+mv "$CLAUDE_DIR" "$BACKUP_DIR"
+echo "    Done."
+
+# ── build minimal ~/.claude with auth only ────────────────────────────────────
+
+echo ""
+echo "==> Building minimal ~/.claude (auth only) ..."
+mkdir -p "$CLAUDE_DIR"
+for dir in sessions config statsig; do
+    if [ -d "$BACKUP_DIR/$dir" ]; then
+        cp -R "$BACKUP_DIR/$dir" "$CLAUDE_DIR/$dir"
+        echo "  copied: $dir"
+    else
+        echo "  not found, skipping: $dir"
+    fi
+done
+
+# ── smoke-test auth ───────────────────────────────────────────────────────────
+
+echo ""
+echo "==> Smoke-testing auth (claude -p 'say: ok') ..."
+if ! claude -p "say: ok" --output-format text > /dev/null 2>&1; then
+    echo "ERROR: auth check failed — claude -p could not authenticate."
+    echo "       Check that sessions/, config/, or statsig/ contain valid credentials."
+    exit 1
+fi
+echo "    Auth OK."
+
+# ── run eval ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "==> Running trigger eval (1 iteration, no holdout) ..."
+PYTHONPATH="$SCRIPT_DIR" python3 -m scripts.run_loop \
+    --eval-set "$SKILL_EVAL_SET" \
+    --skill-path "$SKILL_PATH" \
+    --model claude-sonnet-4-6 \
+    --max-iterations 1 \
+    --holdout 0 \
+    --verbose \
+    --report none \
+    --results-dir "$RESULTS_DIR" \
+    | tee /tmp/eval-results-latest.json
+
+# Print terminal summary and update EVAL-REPORT.md
+LATEST=$(ls -td "$RESULTS_DIR"/* 2>/dev/null | head -1)
+if [ -n "$LATEST" ] && [ -f "$LATEST/results.json" ]; then
+    echo ""
+    echo "========================================"
+    echo " TRIGGER EVAL SUMMARY"
+    echo "========================================"
+    python3 - "$LATEST/results.json" "$WORKSPACE_DIR/EVAL-REPORT.md" <<'PYEOF'
+import json, sys, re
+from datetime import date
+
+data = json.load(open(sys.argv[1]))
+report_path = sys.argv[2]
+iteration = data["history"][0]
+results = iteration["train_results"]
+
+pos = [r for r in results if r["should_trigger"]]
+neg = [r for r in results if not r["should_trigger"]]
+tp = sum(r["triggers"] for r in pos)
+pos_runs = sum(r["runs"] for r in pos)
+fp = sum(r["triggers"] for r in neg)
+neg_runs = sum(r["runs"] for r in neg)
+tn = neg_runs - fp
+fn = pos_runs - tp
+precision = tp / (tp + fp) if (tp + fp) > 0 else 1.0
+recall    = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+accuracy  = (tp + tn) / (tp + tn + fp + fn)
+
+# Terminal output
+print(f" Score:     {iteration['train_passed']}/{iteration['train_total']}")
+print(f" Precision: {precision:.0%}  (of triggers, how many were correct)")
+print(f" Recall:    {recall:.0%}  (of positives, how many fired)")
+print(f" Accuracy:  {accuracy:.0%}")
+print()
+print(" SHOULD TRIGGER:")
+for r in pos:
+    mark = "PASS" if r["pass"] else "FAIL"
+    print(f"  [{mark}] {r['triggers']}/{r['runs']}  {r['query'][:72]}")
+print()
+print(" SHOULD NOT TRIGGER:")
+for r in neg:
+    mark = "PASS" if r["pass"] else "FAIL"
+    print(f"  [{mark}] {r['triggers']}/{r['runs']}  {r['query'][:72]}")
+print()
+print(f" Results saved to: {sys.argv[1]}")
+
+# Build markdown results block
+fn_list = [r for r in pos if not r["pass"]]
+fp_list = [r for r in neg if not r["pass"]]
+
+lines = [f"**Run {date.today()} — isolated, no competing skills**", ""]
+lines += [f"- **Score:** {iteration['train_passed']} / {iteration['train_total']}"]
+lines += [f"- **Precision:** {precision:.0%}"]
+lines += [f"- **Recall:** {recall:.0%}"]
+lines += [f"- **Accuracy:** {accuracy:.0%}"]
+
+if fn_list:
+    lines += ["- **False negatives (should-trigger, did not fire):**"]
+    for r in fn_list:
+        lines += [f"  - {r['query']}"]
+else:
+    lines += ["- **False negatives:** none"]
+
+if fp_list:
+    lines += ["- **False positives (should not trigger, fired anyway):**"]
+    for r in fp_list:
+        lines += [f"  - {r['query']}"]
+else:
+    lines += ["- **False positives:** none"]
+
+lines += [f"- **Decision:** _update after review_"]
+block = "\n".join(lines)
+
+# Replace the results section in EVAL-REPORT.md
+report = open(report_path).read()
+pattern = r'(### Trigger eval results\n)(.*?)(\n## Functional evals)'
+replacement = r'\1\n' + block + r'\n\3'
+updated = re.sub(pattern, replacement, report, flags=re.DOTALL)
+open(report_path, "w").write(updated)
+print(f" EVAL-REPORT.md updated.")
+PYEOF
+    echo "========================================"
+fi

--- a/skills/agent-os-assist/LICENSE
+++ b/skills/agent-os-assist/LICENSE
@@ -1,0 +1,37 @@
+MIT License
+
+Copyright (c) 2026 Philip A Senger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## Third-Party Attribution
+
+This skill describes and helps users work with **Agent OS**, a project by
+CasJam Media LLC (Builder Methods). Agent OS itself is a separate work and is
+not redistributed here.
+
+Upstream project: https://github.com/buildermethods/agent-os
+Upstream copyright: Copyright (c) 2025 CasJam Media LLC (Builder Methods)
+Upstream license: MIT
+
+"Agent OS" and "Builder Methods" are credited to their respective owners.
+This skill is an independent work and is not affiliated with, endorsed by,
+or sponsored by CasJam Media LLC or Builder Methods.

--- a/skills/agent-os-assist/SKILL.md
+++ b/skills/agent-os-assist/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: agent-os-assist
+description: Agent OS reference for installation, slash commands, profiles, and ticket-to-spec workflows. This skill holds reference documentation not in Claude's training; always invoke it before answering any Agent OS question. Invoke whenever the user message contains any of - "agent-os", "Agent OS", "agent os", "~/agent-os", "/agent-os/", "shape-spec", "inject-standards", "discover-standards", "index-standards", "plan-product". Also invoke when the user asks to - turn a Jira ticket, GitHub issue number, or GitHub issue URL into a spec or plan; set up corporate or enterprise coding standards; commit or version-control an agent-os folder; configure profile inheritance in config.yml; write their first standard after installing agent-os; or recover a broken spec without losing history.
+allowed-tools: Read, Grep, Glob, Bash, Write, Edit
+license: MIT
+---
+
+# Agent OS Assist
+
+Help users install, configure, and use Agent OS v3, the Builder Methods system for managing coding standards in AI-assisted development.
+
+## How to use the references
+
+Read on demand. Do not preload.
+
+| If the user is asking about... | Read |
+|---|---|
+| "How do I get started with..." workflows | `references/getting-started.md` |
+| Installing or scaffolding | `references/installation.md` |
+| Slash commands behavior or process | `references/commands.md` |
+| Profiles, inheritance, `config.yml` | `references/profiles.md` |
+| Writing standards, index.yml, quality | `references/standards.md` |
+| File layout, what to commit | `references/file-structure.md` |
+| Migrating from v2 | `references/v2-vs-v3.md` |
+| Standards vs Skills distinction | `references/standards-vs-skills.md` |
+
+## Version awareness
+
+Before giving substantive guidance, read `~/agent-os/config.yml` and check the `version:` field.
+
+- If `3.x`: proceed normally.
+- `4.x` or higher: tell the user once that this skill is calibrated to v3 and may be out of date. Ask whether to proceed. If yes, caveat any v3-specific claim as "v3 behavior, may have changed in v4".
+- Missing or below `3.0.0`: treat as a v2 install. See `references/v2-vs-v3.md` and recommend migration.
+
+Do not refuse to help on a version mismatch.
+
+## Core facts
+
+- v3 released January 2026. Subagents and dedicated implementation commands were retired. Plan mode plus `/shape-spec` handles spec writing now.
+- Two-part install: base at `~/agent-os/`, project at `<repo>/agent-os/` plus `<repo>/.claude/commands/agent-os/`.
+- Profiles are folders. Any directory under `~/agent-os/profiles/` containing a `standards/` subfolder is a valid profile. No registration required.
+- Inheritance lives in `~/agent-os/config.yml`, not in per-profile `profile-config.yml` files. That was v2. Child overrides parent when filenames collide.
+- Five slash commands: `/discover-standards`, `/index-standards`, `/inject-standards`, `/plan-product`, `/shape-spec`.
+- Standards are declarative (what conventions). Skills are procedural (how to do tasks). They compose: a Skill can `@`-reference standards.
+- `index.yml` drives auto-suggest for `/inject-standards`. Vague descriptions break matching.
+
+## Default workflow
+
+1. Identify the goal: installing, getting started, running a command, turning a ticket into a spec, or recovering a broken spec.
+2. Confirm the target: base install (`~/agent-os/`), a project (`<repo>/agent-os/`), or a profile (`~/agent-os/profiles/<name>/`).
+3. Pull the relevant reference from the table above.
+4. Be concrete. When explaining config, show the exact YAML. When explaining commands, show the exact slash command.
+
+## Ticket-to-spec workflow
+
+When the user provides a Jira or GitHub ticket (key, URL, or pasted content):
+1. Read `references/commands.md` to confirm the correct command is `/shape-spec`.
+2. Help the user extract the scope, constraints, and acceptance criteria from the ticket.
+3. Guide them to run `/shape-spec` in plan mode with that context.
+4. Do not fetch URLs directly. Ask the user to paste the ticket content if only a URL is provided.
+
+## Spec recovery
+
+When a spec produced by `/shape-spec` is wrong:
+1. Diagnose which layer failed: shape (scope), plan (steps), standards (conventions), or drift (context lost).
+2. Recommend editing the spec file directly or re-running `/shape-spec` with refined input.
+3. Never recommend discarding the conversation history.
+
+## Don't
+
+- Don't invent commands or flags. The canonical list is in `references/commands.md`.
+- Don't suggest `profile-config.yml`. That is a v2 artifact.
+- Don't recommend installing subagents under `.claude/agents/agent-os/`. That is a v2 artifact.
+- Don't guess paths. Verify with `ls` before referencing them.
+
+> Agent OS is a project by CasJam Media LLC (Builder Methods): https://github.com/buildermethods/agent-os. See `LICENSE` for attribution.

--- a/skills/agent-os-assist/references/commands.md
+++ b/skills/agent-os-assist/references/commands.md
@@ -1,0 +1,89 @@
+# The 5 Slash Commands
+
+All commands live in `.claude/commands/agent-os/` (project) and `~/agent-os/commands/agent-os/` (source).
+
+## /discover-standards
+
+Extracts tribal knowledge from a codebase into documented standards.
+
+**Process:**
+1. Determine focus area (auto-detect, or specify: `/discover-standards api`)
+2. Analyze 5–10 representative files for unusual / opinionated / consistent / tribal patterns
+3. Ask 1–2 targeted "why does this exist?" questions per pattern
+4. Draft standards and ask the user to confirm, edit, or skip each
+5. Update `index.yml`
+6. Offer to continue in another area
+
+Runs `/index-standards` automatically as its final step.
+
+**When to run:** on existing codebases, after a major refactor, when onboarding, periodically to capture drift.
+
+## /index-standards
+
+Rebuilds and maintains `agent-os/standards/index.yml`.
+
+- Scans for all standards files
+- Adds missing entries (prompts for descriptions)
+- Removes entries for deleted files
+- Alphabetizes and cleans up
+
+**When to run:** after manually creating or deleting standards files, or when `/inject-standards` auto-suggestions seem off.
+
+## /inject-standards
+
+Deploys relevant standards into the current context.
+
+**Auto-suggest mode:**
+```
+/inject-standards
+```
+Reads `index.yml`, matches descriptions against the conversation, presents 2–5 relevant standards to confirm.
+
+**Explicit mode:**
+```
+/inject-standards api
+/inject-standards api/response-format
+/inject-standards api/response-format api/auth
+```
+
+**Output format depends on the scenario:**
+- **Conversation:** reads full standards content directly into context.
+- **Creating a skill:** asks whether to embed content (self-contained) or `@`-file references (stays current).
+- **Plan mode:** same choice as creating a skill, embed snapshot or reference files.
+
+Also surfaces related Skills from `.claude/skills/`. Names them, does not invoke them.
+
+## /plan-product
+
+Creates foundational product documentation through interactive conversation. Generates in `agent-os/product/`:
+
+- `mission.md`: vision, target users, core problems.
+- `roadmap.md`: phased plan with prioritized features.
+- `tech-stack.md`: technical stack choices.
+
+**When to run:** new project setup, before using `/shape-spec`, onboarding team members.
+
+`/shape-spec` reads `agent-os/product/` to align specs with product goals.
+
+## /shape-spec
+
+Run **inside plan mode**. Gathers context and creates a persistent spec folder.
+
+**Process:**
+1. `/plan` to enter plan mode
+2. `/shape-spec`
+3. Answer shaping questions (what we're building, visuals, reference code, product alignment, applicable standards)
+4. Review the plan (Task 1 = save spec documentation)
+5. Approve and execute
+
+**Output folder:**
+```
+agent-os/specs/YYYY-MM-DD-HHMM-<slug>/
+├── plan.md         # Full implementation plan
+├── shape.md        # Scope, decisions, context
+├── references.md   # Pointers to similar code
+└── standards.md    # Full content of relevant standards
+```
+
+**Use `/shape-spec` when:** decisions need to persist, you have visuals, significant feature.
+**Use plain plan mode when:** quick task, no persistence needed.

--- a/skills/agent-os-assist/references/file-structure.md
+++ b/skills/agent-os-assist/references/file-structure.md
@@ -1,0 +1,75 @@
+# File Structure
+
+Agent OS lives in two places: a **base installation** on the machine and a **project installation** in each repo.
+
+## Base installation `~/agent-os/`
+
+```
+~/agent-os/
+  commands/
+    agent-os/                   # 5 slash command .md files (source)
+      discover-standards.md
+      index-standards.md
+      inject-standards.md
+      plan-product.md
+      shape-spec.md
+  profiles/
+    <profile-name>/
+      standards/                # .md standards files only. No profile-config.yml in v3.
+  scripts/
+    project-install.sh
+    sync-to-profile.sh
+    common-functions.sh
+  config.yml                    # version, default_profile, profiles: (inheritance)
+```
+
+## Project installation `your-project/`
+
+```
+your-project/
+  agent-os/
+    standards/
+      <domain>/
+        <standard>.md
+      index.yml                 # Index for matching
+    specs/
+      YYYY-MM-DD-HHMM-<slug>/
+        plan.md
+        shape.md
+        standards.md
+        references.md
+        visuals/
+    product/
+      mission.md
+      roadmap.md
+      tech-stack.md
+  .claude/
+    commands/
+      agent-os/                 # 5 slash command .md files (copied from base)
+        discover-standards.md
+        index-standards.md
+        inject-standards.md
+        plan-product.md
+        shape-spec.md
+```
+
+## What to commit
+
+| Path | Commit? | Reason |
+|---|---|---|
+| `agent-os/standards/` | Yes | Share conventions with the team |
+| `agent-os/product/` | Yes | Share product context |
+| `agent-os/specs/` | Yes | Preserve project history |
+| `.claude/commands/agent-os/` | Optional | Team can regenerate from base install with `--commands-only` |
+
+`.claude/commands/agent-os/` is a copy of the source commands; some teams prefer to commit it for reproducibility, others gitignore it.
+
+## Things that should NOT exist in v3
+
+If you see any of these, flag them as v2 leftovers:
+
+- `.claude/agents/agent-os/` (subagents, retired)
+- `~/agent-os/profiles/<name>/profile-config.yml` (inheritance moved to `config.yml`)
+- `~/agent-os/profiles/<name>/agents/`
+- `~/agent-os/profiles/<name>/commands/`
+- `~/agent-os/profiles/<name>/workflows/`

--- a/skills/agent-os-assist/references/getting-started.md
+++ b/skills/agent-os-assist/references/getting-started.md
@@ -1,0 +1,227 @@
+# Getting Started
+
+Pick the section that matches the user's situation. Each one is a self-contained walkthrough.
+
+| Situation | Section |
+|---|---|
+| Brand new machine, no Agent OS yet | [1. Bootstrap from zero](#1-bootstrap-from-zero) |
+| Just cloned a repo that already uses Agent OS | [2. Joining a repo that has Agent OS](#2-joining-a-repo-that-has-agent-os) |
+| Have a Jira / GitHub / Linear ticket, want to plan and execute | [3. From ticket to executed spec](#3-from-ticket-to-executed-spec) |
+| A spec was generated badly, or implementation drifted | [4. Recovering a spec that went wrong](#4-recovering-a-spec-that-went-wrong) |
+| Long task, context window filling up | [5. Saving context with the LLM effectively](#5-saving-context-with-the-llm-effectively) |
+
+---
+
+## 1. Bootstrap from zero
+
+The user has nothing installed.
+
+**Step 1. Install the base.**
+
+```bash
+cd ~
+git clone https://github.com/buildermethods/agent-os.git && rm -rf ~/agent-os/.git
+```
+
+**Step 2. Verify the base.**
+
+```bash
+cat ~/agent-os/config.yml          # confirm version: 3.0.0
+ls ~/agent-os/profiles/            # see what profiles ship
+ls ~/agent-os/commands/agent-os/   # confirm 5 .md files
+```
+
+**Step 3. Create a profile.**
+
+If none of the shipped profiles fit, create one:
+
+```bash
+mkdir -p ~/agent-os/profiles/my-profile/standards
+```
+
+Edit `~/agent-os/config.yml`:
+```yaml
+version: 3.0.0
+default_profile: my-profile
+profiles:
+  my-profile: {}
+```
+
+Drop 2 to 4 starter standards into `~/agent-os/profiles/my-profile/standards/`. Use the quality rules in `standards.md`.
+
+**Step 4. Install into a project.**
+
+```bash
+cd /path/to/project
+~/agent-os/scripts/project-install.sh --profile my-profile
+```
+
+**Step 5. First-time refinement.**
+
+Run `/discover-standards` inside the project. It will surface tribal knowledge and prompt the user to confirm or skip each candidate. This is the fastest way to seed a useful profile.
+
+If standards refined inside the project should propagate to the profile:
+```bash
+~/agent-os/scripts/sync-to-profile.sh
+```
+
+---
+
+## 2. Joining a repo that has Agent OS
+
+The user just cloned a repo that already has `agent-os/` and `.claude/commands/agent-os/`.
+
+**Step 1. Confirm Agent OS is installed locally.**
+
+```bash
+test -d ~/agent-os && echo "ok" || echo "missing"
+```
+
+If missing, run the bootstrap from section 1 first. Without the base install, `sync-to-profile.sh` and `project-install.sh --commands-only` won't work.
+
+**Step 2. Read the project's product context.**
+
+If `agent-os/product/` exists, read `mission.md`, `roadmap.md`, and `tech-stack.md` before doing anything else. They frame every spec.
+
+**Step 3. Read the standards index.**
+
+```bash
+cat agent-os/standards/index.yml
+ls agent-os/standards/
+```
+
+Skim a handful of standards that look central to the work the user plans to do. Do not read all of them up front. Standards exist to be injected on demand.
+
+**Step 4. Check command versions.**
+
+If the slash commands look stale or behave oddly:
+```bash
+~/agent-os/scripts/project-install.sh --commands-only
+```
+This refreshes `.claude/commands/agent-os/` without touching standards.
+
+**Step 5. Look at recent specs for tone.**
+
+```bash
+ls agent-os/specs/ | tail -5
+```
+Open one or two recent spec folders. Reading `shape.md` and `plan.md` from a recent feature shows the team's voice and depth of detail expected.
+
+---
+
+## 3. From ticket to executed spec
+
+The user has a ticket in Jira, GitHub, Linear, or similar, and wants Agent OS to drive the work.
+
+**Step 1. Pull the ticket content into context.**
+
+Use the appropriate MCP or CLI to fetch the ticket. Examples:
+- GitHub: `gh issue view <number>` or the GitHub MCP `issue_read`.
+- Jira / Atlassian: the Atlassian Rovo MCP.
+- Linear: the Linear MCP if available, otherwise paste the description.
+
+Capture: title, description, acceptance criteria, linked tickets, attached visuals.
+
+**Step 2. Confirm product alignment.**
+
+If `agent-os/product/` exists, cross-check the ticket against `mission.md` and `roadmap.md`. Flag mismatches before planning. A ticket that conflicts with the roadmap is the user's call to escalate, not yours to silently reconcile.
+
+**Step 3. Enter plan mode.**
+
+```
+/plan
+```
+
+**Step 4. Run /shape-spec.**
+
+```
+/shape-spec
+```
+
+Answer the shaping questions:
+- What are we building? (paste ticket summary plus any clarifications)
+- Visuals? (attach mockups, link Figma, paste screenshots)
+- Reference code? (point at similar features already in the repo)
+- Product alignment? (cite which roadmap item this serves)
+- Which standards apply? (let auto-suggest run, then refine)
+
+**Step 5. Review the plan.**
+
+Task 1 of the plan saves the spec folder. Read the full plan before approving. If the plan misreads the ticket, fix it now: it is cheaper to revise the plan than to revise the implementation.
+
+**Step 6. Approve and execute.**
+
+After approval, the spec folder lands at `agent-os/specs/YYYY-MM-DD-HHMM-<slug>/` with `plan.md`, `shape.md`, `references.md`, `standards.md`. Implementation proceeds against this folder. The spec persists, so future sessions can pick up mid-implementation.
+
+**Step 7. Link back to the ticket.**
+
+Comment on the ticket with the spec folder path, or include it in the PR description. This closes the loop between the tracking system and Agent OS.
+
+---
+
+## 4. Recovering a spec that went wrong
+
+Symptoms: the plan is wrong, the implementation drifted from the spec, scope crept, or the standards section is missing pieces.
+
+**Step 1. Diagnose where it broke.**
+
+Open the spec folder. Read in this order:
+1. `shape.md`. Was the scope captured correctly? If not, the shaping conversation went wrong; everything downstream inherits that error.
+2. `plan.md`. Does the plan match the shape? If shape is fine but the plan misreads it, the issue is at planning time.
+3. `standards.md`. Are the right standards present? Missing standards explain "why does the code violate convention X" type drift.
+4. The actual code changes vs. the plan. If shape and plan are sound but the code drifted, the failure is at implementation.
+
+**Step 2. Choose a recovery path.**
+
+| Where it broke | Recovery |
+|---|---|
+| Shape wrong | Re-enter plan mode, run `/shape-spec` again, save into a new dated folder. Mark the old folder superseded in its `shape.md`. Do not edit the old folder in place; preserve history. |
+| Plan wrong, shape fine | Re-enter plan mode, paste the existing `shape.md`, ask for a new plan. Replace `plan.md` in the same folder. Note the revision at the top. |
+| Missing standards | Run `/inject-standards <domain>` in plan mode, then re-run `/shape-spec` to refresh `standards.md`. |
+| Code drifted from a sound plan | Treat as a normal code review. Compare diff to `plan.md`, list each deviation, decide each one as "accept and update plan" or "revert to match plan". |
+
+**Step 3. Update the index if standards changed.**
+
+If the recovery surfaced a missing or stale standard, run `/index-standards` so future auto-suggest works.
+
+**Step 4. Capture the lesson.**
+
+If the failure mode is likely to recur (e.g., shaping kept missing a constraint), add or refine a standard so the next spec catches it. This is how the system gets stronger over time.
+
+---
+
+## 5. Saving context with the LLM effectively
+
+Agent OS is built around the idea that context is precious. These practices keep sessions productive across long tasks.
+
+**Inject only what is needed.**
+
+`/inject-standards` loads full standards content into context. Pull only the domains relevant to the current work. Resist `/inject-standards api/* db/* naming` when the task is one API endpoint.
+
+**Prefer file references over embedded content for Skills.**
+
+When `/inject-standards` is called inside Skill creation or plan mode, it offers two output formats:
+- Embed the content (snapshot, self-contained, drifts as standards evolve).
+- `@`-reference the files (always fresh, requires the project to have those standards).
+
+For long-lived Skills used inside repos that have Agent OS, prefer references. Snapshots are appropriate when the Skill must work in repos without Agent OS installed.
+
+**Persist decisions to specs, not to chat.**
+
+Anything decided in a `/shape-spec` conversation lives in `shape.md` and survives session boundaries. Decisions made in regular chat evaporate when the context is compacted. If a discussion produces a real decision, capture it in the spec folder.
+
+**Use the spec folder as the resume point.**
+
+When returning to a feature mid-flight, do not re-explain it. Read `shape.md`, `plan.md`, and recent diffs. The spec is the handoff document.
+
+**Compact when the conversation drifts.**
+
+Long meandering threads bloat the context window with dead ends. When the path forward is clear, summarize the conclusions, save them to the spec folder if relevant, and start a fresh session pointed at the spec folder.
+
+**Keep `index.yml` descriptions specific.**
+
+Auto-suggest matching is only as good as the descriptions. A description like `"API stuff"` will either over-trigger (wasting context) or under-trigger (missing the standards that matter). Specific descriptions reduce wasted injection cycles.
+
+**Treat the product folder as load-bearing.**
+
+`mission.md`, `roadmap.md`, and `tech-stack.md` are short on purpose. They give every future spec a frame without burning context. Keep them current. Stale product docs poison every spec that reads them.

--- a/skills/agent-os-assist/references/installation.md
+++ b/skills/agent-os-assist/references/installation.md
@@ -1,0 +1,58 @@
+# Agent OS Installation
+
+Agent OS is a two-part install: a base at `~/agent-os/` and a per-project install under `<repo>/agent-os/`.
+
+## Step 1 — Install the base
+
+Clone the repo into your home directory:
+
+```bash
+git clone https://github.com/buildermethods/agent-os.git ~/agent-os
+```
+
+The base provides profiles, scripts, and the slash commands that get copied into projects.
+
+## Step 2 — Install into a project
+
+From inside any git repo, run:
+
+```bash
+bash ~/agent-os/scripts/project-install.sh
+```
+
+This creates two things in your repo:
+- `agent-os/` — copied standards from your active profile
+- `.claude/commands/agent-os/` — the five slash commands
+
+### Options
+
+| Flag | What it does |
+|---|---|
+| `--profile <name>` | Use a named profile instead of the default |
+| `--commands-only` | Refresh commands only; leave existing standards untouched |
+| `--verbose` | Show detailed output |
+
+Example with a profile:
+```bash
+bash ~/agent-os/scripts/project-install.sh --profile node-express
+```
+
+## Verifying the install
+
+After running the script, confirm these paths exist:
+
+```
+<repo>/agent-os/standards/        # your profile's standards
+<repo>/.claude/commands/agent-os/ # the five slash commands
+```
+
+Check the active profile in `~/agent-os/config.yml`:
+
+```yaml
+version: 3.0.0
+default_profile: default
+```
+
+## What gets committed
+
+Commit both `agent-os/` and `.claude/commands/agent-os/` to version control. This keeps the team on the same standards and commands. See `references/file-structure.md` for the full layout.

--- a/skills/agent-os-assist/references/profiles.md
+++ b/skills/agent-os-assist/references/profiles.md
@@ -1,0 +1,63 @@
+# Profiles
+
+A **profile** is a named folder under `~/agent-os/profiles/<name>/` containing a `standards/` subfolder of `.md` files.
+
+## Rules
+
+- Any directory under `~/agent-os/profiles/` containing `standards/` is a valid profile. No registration step.
+- The `profiles:` section in `~/agent-os/config.yml` only declares **inheritance**. Omitting a profile from `config.yml` means it stands alone.
+- When inheriting, child profiles override parents file-by-file: same filename in both → child wins.
+- Profiles in v3 contain **only `standards/`**. No `agents/`, no `commands/`, no `workflows/`, no `profile-config.yml`.
+
+## config.yml format
+
+```yaml
+version: 3.0.0
+default_profile: my-rails-app
+profiles:
+  my-rails-app:
+    inherits_from: rails-base
+  rails-base:
+    inherits_from: ruby-general
+```
+
+Three-level inheritance is fine; deeper chains start to be a smell.
+
+## Common naming patterns
+
+- **By tech stack:** `rails`, `nextjs`, `django`, `go-services`
+- **By client:** `client-acme`, `client-xyz`
+- **By context:** `work`, `personal`, `consulting`
+
+Pick one axis and stick with it. Mixing axes (`rails` next to `client-acme`) leads to confusion about which profile to pick for a new project.
+
+## When to create a new profile vs. extend an existing one
+
+Create a **new profile** when:
+- The tech stack is materially different
+- A client requires standards that conflict with your defaults
+- You want a clean slate for experimentation
+
+Extend (inherit from) an existing profile when:
+- 70%+ of standards would be the same
+- You only need to override a handful of conventions
+- You want upstream changes to flow down
+
+## Sharing profiles with a team
+
+Three workable patterns:
+1. **Commit `agent-os/standards/` per project.** Lowest setup cost, but duplication across repos.
+2. **Shared profile name.** Every team member maintains the same profile name locally; sync via `sync-to-profile.sh`.
+3. **Dedicated standards repo.** Clone into `~/agent-os/profiles/<name>/` and treat the profile as a versioned artifact.
+
+Pattern 3 scales best for organizations.
+
+## Auditing a profile
+
+When asked to review `~/agent-os/profiles/<name>/`:
+
+1. Confirm `standards/` exists with `.md` files
+2. Flag any v2 artifacts (`agents/`, `commands/`, `workflows/`, `profile-config.yml`)
+3. Read `~/agent-os/config.yml`. Verify `version: 3.0.0`; if `inherits_from` is set, verify the parent folder exists.
+4. Apply the standards quality rules (see `standards.md`)
+5. Flag standards that document obvious framework behavior

--- a/skills/agent-os-assist/references/standards-vs-skills.md
+++ b/skills/agent-os-assist/references/standards-vs-skills.md
@@ -1,0 +1,42 @@
+# Standards vs Skills
+
+Standards and Skills solve different problems. Use the right tool, and compose them when both apply.
+
+## Comparison
+
+| | Standards | Skills |
+|---|---|---|
+| **Type** | Declarative: what conventions | Procedural: how to do tasks |
+| **Location** | `agent-os/standards/` | `.claude/skills/` |
+| **Invocation** | Explicit via `/inject-standards` (or auto-suggest from `index.yml`) | Auto-detected by Claude from skill descriptions |
+| **Loaded** | Only when injected | Description always in context; body when triggered |
+| **Best for** | "We use X envelope for API responses" | "When making a PDF report, do steps 1–5" |
+
+## Use `/inject-standards` when
+
+- You want explicit control over which conventions apply
+- The work spans multiple domains (API + DB + naming)
+- You're authoring a Skill and want to bake in conventions
+
+## Use Skills when
+
+- There's a repeatable procedure to automate
+- You want auto-detection ("when the user mentions X, do Y")
+- The task is self-contained with clear inputs and outputs
+
+## Best pattern: compose them
+
+A Skill provides the procedure; standards provide the conventions. The Skill `@`-references the standards files so they stay current:
+
+```markdown
+Before implementing, read:
+- @agent-os/standards/api/response-format.md
+- @agent-os/standards/api/error-handling.md
+```
+
+This combination gives:
+- **Procedural automation** from the Skill (the *how*)
+- **Declarative conventions** from the Standards (the *what*)
+- **Single source of truth.** When standards change, the Skill picks up the new content automatically.
+
+If a Skill is bundled or distributed externally and can't rely on a project's standards being present, embed the content instead of referencing it. `/inject-standards` will offer this choice when invoked inside Skill creation.

--- a/skills/agent-os-assist/references/standards.md
+++ b/skills/agent-os-assist/references/standards.md
@@ -1,0 +1,112 @@
+# Standards
+
+Standards are **declarative documentation of coding conventions**: patterns and rules, not step-by-step procedures.
+
+Examples of valid standards content:
+- "All API responses use this envelope structure"
+- "Error codes follow this naming convention"
+- "Database migrations must include rollback logic"
+
+## Layout
+
+```
+agent-os/standards/
+├── api/
+│   ├── response-format.md
+│   └── error-handling.md
+├── database/
+│   └── migrations.md
+├── naming-conventions.md       # Root-level standard
+└── index.yml
+```
+
+## index.yml format
+
+```yaml
+api:
+  response-format:
+    description: API response envelope structure, status codes
+  error-handling:
+    description: Error code conventions, exception handling
+root:
+  naming-conventions:
+    description: File, class, and variable naming conventions
+```
+
+`root` is a reserved keyword for standards files at the top level of `agent-os/standards/` (not inside subfolders).
+
+### What makes a good description
+
+The description is what `/inject-standards` uses for auto-matching. Vague descriptions break matching.
+
+- **Bad:** `description: API stuff`
+- **Good:** `description: API response envelope structure, status codes, success/error keys`
+
+Include the specific concepts and keywords that would appear in a conversation about this topic.
+
+## Quality rules: when a standard earns its keep
+
+Standards consume context-window tokens every time they're injected. Each one must pay rent.
+
+**Write a standard for:**
+- Patterns that are unusual or unconventional
+- Opinionated choices that could have gone differently
+- Tribal knowledge a new developer wouldn't know without being told
+- Things people frequently get wrong
+
+**Do NOT write a standard for:**
+- Standard framework patterns (e.g., "controllers go in `app/controllers/`" in Rails)
+- Universally obvious best practices
+- Things that the code already makes clear at a glance
+
+## Writing style
+
+- **Lead with the rule.** State what to do, then why.
+- **Use code examples.** Show, don't tell.
+- **Bullets over paragraphs.** Scannable beats readable.
+- **One concept per file.** Don't combine unrelated patterns.
+
+## Good example
+
+````markdown
+# Error Responses
+
+Use error codes: `AUTH_001`, `DB_001`, `VAL_001`.
+
+```json
+{ "success": false, "error": { "code": "AUTH_001", "message": "..." } }
+```
+
+- Always include both code and message
+- Log full error server-side, return safe message to client
+````
+
+Why this works: rule on line 1, example immediately, three bullets cover the operational nuance, fits on a screen.
+
+## Bad example
+
+```markdown
+# Error Handling Guidelines
+
+When an error occurs in our application, we have established a consistent
+pattern for how errors should be formatted. This document describes the
+philosophy behind our approach...
+[continues for 3 more paragraphs with no code example]
+```
+
+Why it fails: no rule on line 1, no code example, paragraph-heavy, philosophical filler.
+
+## Common audit findings
+
+When critiquing a standards collection, look for:
+
+| Finding | Severity | Fix |
+|---|---|---|
+| Paragraph-heavy with no code | Warning | Rewrite leading with the rule + example |
+| Documents framework defaults | Blocking | Delete |
+| Multiple unrelated concepts in one file | Warning | Split into separate files |
+| index.yml description too vague | Warning | Rewrite with specific keywords |
+| Orphan index.yml entry (file deleted) | Blocking | Run `/index-standards` |
+| Standards file not in index.yml | Blocking | Run `/index-standards` |
+| File over ~100 lines | Suggestion | Likely combining concepts; split |
+| No code examples anywhere in collection | Warning | Add examples to top 3 most-used standards first |

--- a/skills/agent-os-assist/references/v2-vs-v3.md
+++ b/skills/agent-os-assist/references/v2-vs-v3.md
@@ -1,0 +1,48 @@
+# v2 vs v3
+
+Agent OS v3 was released January 2026. The differences below matter for migration and for spotting v2 artifacts during a review.
+
+## Key differences
+
+| Area | v2 | v3 |
+|---|---|---|
+| Subagents | `.claude/agents/agent-os/` installed | Retired. Frontier models handle it |
+| Spec writing | Dedicated implementation commands | Plan mode + `/shape-spec` |
+| Profile inheritance | `profile-config.yml` inside each profile | `config.yml` at `~/agent-os/` root |
+| Standards discovery | Manual | `/discover-standards` |
+| Index maintenance | Manual | `/index-standards` |
+| Profile sync | Manual copy | `~/agent-os/scripts/sync-to-profile.sh` |
+| Profile contents | `standards/`, `agents/`, `commands/`, `workflows/` | `standards/` only |
+
+## Migrating from v2
+
+1. Remove v2 artifacts:
+   ```bash
+   rm -rf .claude/agents/agent-os/
+   rm -rf .claude/commands/agent-os/
+   ```
+2. Reinstall v3 commands without disturbing standards:
+   ```bash
+   ~/agent-os/scripts/project-install.sh --commands-only
+   ```
+3. Move inheritance config from per-profile `profile-config.yml` files into the root `~/agent-os/config.yml`:
+   ```yaml
+   version: 3.0.0
+   default_profile: my-app
+   profiles:
+     my-app:
+       inherits_from: rails-base
+   ```
+4. Delete the `profile-config.yml` files and any `agents/` / `commands/` / `workflows/` subdirs inside each profile.
+5. Standards files, specs, and product docs transfer **without modification**.
+
+## How to spot a v2 install during a review
+
+Any of these is a v2 leftover:
+
+- A `profile-config.yml` anywhere under `~/agent-os/profiles/`
+- `agents/`, `commands/`, or `workflows/` subdirs inside a profile
+- `.claude/agents/agent-os/` in a project
+- `~/agent-os/config.yml` missing or with `version` below `3.0.0`
+
+When you see these, recommend the migration steps above before doing any other audit work. Most other findings depend on a clean v3 baseline.

--- a/skills/agent-os-profile-critique/.skillignore
+++ b/skills/agent-os-profile-critique/.skillignore
@@ -1,0 +1,1 @@
+.workspace/

--- a/skills/agent-os-profile-critique/.workspace/EVAL-REPORT.md
+++ b/skills/agent-os-profile-critique/.workspace/EVAL-REPORT.md
@@ -1,0 +1,114 @@
+# Eval Report — agent-os-profile-critique
+
+This document describes the eval suite for the `agent-os-profile-critique` skill, what each test
+verifies, and where to record results after a run. Results sections are stubbed until
+the suite is executed.
+
+## Files under test
+
+- `skills/agent-os-profile-critique/SKILL.md`
+- `skills/agent-os-profile-critique/references/*.md` — 6 reference files
+- `skills/agent-os-profile-critique/.workspace/evals/trigger-evals.json` — 15 queries
+- `skills/agent-os-profile-critique/.workspace/evals/evals.json` — 1 functional case
+- `skills/agent-os-profile-critique/.workspace/evals/files/v2-profile/` — fixture for case 1
+
+## Trigger evals
+
+Tests whether the skill description activates on the right prompts and stays quiet on
+the wrong ones. Target: 95% (14/15).
+
+Run (from repo root):
+```bash
+bash skills/agent-os-profile-critique/.workspace/run-trigger-eval.sh
+```
+
+### Should-trigger queries (3)
+
+| # | Query | What it verifies |
+|---|---|---|
+| 1 | Here's a standard I wrote for my agent-os profile, is it any good? Always use descriptive variable names. | Standards critique with realistic pasted content and agent-os context |
+| 2 | Can you review my agent-os profile and tell me what's wrong? | Profile review, natural phrasing with agent-os keyword |
+| 3 | validate my agent-os profile setup | Profile validation, terse natural phrasing |
+
+### Should-not-trigger queries (10)
+
+These are tricky near-misses that distinguish this skill from generic project work.
+
+| # | Query | Why it must NOT trigger |
+|---|---|---|
+| 1 | Set up a new Node.js project structure with Express and TypeScript | Generic scaffolding, no Agent OS context |
+| 2 | Audit my package.json for outdated dependencies and security issues | "Audit" keyword present but unrelated to Agent OS |
+| 3 | Help me write a coding standard document for our team's React work | "Standard" keyword but no Agent OS context |
+| 4 | How do I configure my .eslintrc.yml for monorepo workspaces? | Config-file question for an unrelated tool |
+| 5 | Review this REST API design and tell me where the security holes are | "Review" keyword but API-design domain |
+| 6 | What's the best operating system for running coding agents locally? | Literal "operating system" near-miss for "agent os" |
+| 7 | Create a config.yml for my GitHub Actions deployment workflow | `config.yml` in unrelated product context |
+| 8 | Write me an OpenAPI spec for the /users endpoint | "Spec" keyword but OpenAPI, not Agent OS |
+| 9 | How do I customize my GitHub profile README? | "Profile" keyword in unrelated context |
+| 10 | Set up a CI/CD pipeline spec for our staging deployment | "Spec" plus "set up" but DevOps domain |
+
+### Trigger eval results
+
+**Run 2026-05-10 — isolated, no competing skills**
+
+- **Score:** 10 / 15
+- **Precision:** 100%
+- **Recall:** 7%
+- **Accuracy:** 69%
+- **False negatives (should-trigger, did not fire):**
+  - Here's a standard I wrote for my agent-os profile, is it any good?
+
+Always use descriptive variable names.
+  - audit my agent-os profile at ~/agent-os/profiles/my-company/ and give me a severity-tagged report
+  - Can you review my agent-os profile and tell me what's wrong?
+  - Is this agent-os standard any good?
+
+# Error Handling
+
+Always handle errors gracefully.
+  - I think my agent-os profile has some v2 artifacts in it, can you check?
+- **False positives:** none
+- **Decision:** _update after review_
+
+## Functional evals
+
+Tests whether the skill produces correct output. One case.
+
+### Case 1 — `audit-v2-profile-flags-artifacts`
+
+**Prompt:** Audit the Agent OS profile at `.workspace/evals/files/v2-profile/` and give
+me severity-tagged findings.
+
+**Fixtures:**
+- `.workspace/evals/files/v2-profile/profile-config.yml` — a v2 artifact
+- `.workspace/evals/files/v2-profile/standards/python-style.md` — a deliberately weak
+  standard (restates PEP 8, no code examples, no leading rule)
+
+**What it verifies:**
+- The skill reads the fixture before recommending changes.
+- The skill flags `profile-config.yml` as a v2 artifact.
+- The skill recommends moving inheritance to `~/agent-os/config.yml`.
+- The skill critiques `python-style.md` for restating framework defaults, missing a
+  leading rule, and missing code examples.
+- Each finding includes a severity label, a specific file path, and a concrete fix.
+
+### Functional eval results
+
+_Pending first run._
+
+## Acceptance criteria coverage
+
+| Criterion | Verified by |
+|---|---|
+| Skill loads in Claude Code without validation errors | Manual: `ls`, frontmatter check |
+| Description triggers reliably on critique/audit/review queries | Trigger evals (target 95%) |
+| Skill does NOT trigger on getting-started, commands, or ticket-to-spec queries | Trigger evals (should-not-trigger) |
+| Skill flags v2 artifacts | Functional case 1 |
+| Skill reads fixtures before recommending changes | Functional case 1 |
+| Each finding has severity, file path, and concrete fix | Functional case 1 |
+| No em-dashes; imperative voice throughout | Manual: `grep -n '—'` |
+
+## How to update this report
+
+After each run, replace the corresponding "_Pending first run._" block with the
+actual numbers and observations.

--- a/skills/agent-os-profile-critique/.workspace/evals/evals.json
+++ b/skills/agent-os-profile-critique/.workspace/evals/evals.json
@@ -1,0 +1,25 @@
+{
+  "skill_name": "agent-os-profile-critique",
+  "evals": [
+    {
+      "id": 1,
+      "name": "audit-v2-profile-flags-artifacts",
+      "prompt": "Audit the Agent OS profile at .workspace/evals/files/v2-profile/ and give me severity-tagged findings.",
+      "expected_output": "Identifies the profile as a v2 install because it contains profile-config.yml. Reports a blocking finding referencing profile-config.yml and explains that v3 moves inheritance to ~/agent-os/config.yml. Critiques standards/python-style.md for restating framework defaults (PEP 8), missing a leading rule, and missing code examples. Returns findings as a list with severity (blocking, warning, or suggestion), the specific file, and a concrete fix for each.",
+      "files": [
+        ".workspace/evals/files/v2-profile/profile-config.yml",
+        ".workspace/evals/files/v2-profile/standards/python-style.md"
+      ],
+      "expectations": [
+        "The output flags profile-config.yml as a v2 artifact",
+        "The output recommends moving inheritance configuration to ~/agent-os/config.yml",
+        "The output critiques python-style.md for restating PEP 8 / framework defaults",
+        "The output notes python-style.md lacks a code example",
+        "The output notes python-style.md does not lead with a clear rule on line 1",
+        "Each finding includes a severity label (blocking, warning, or suggestion)",
+        "Each finding cites a specific file path",
+        "Each finding includes a concrete fix recommendation"
+      ]
+    }
+  ]
+}

--- a/skills/agent-os-profile-critique/.workspace/evals/files/v2-profile/profile-config.yml
+++ b/skills/agent-os-profile-critique/.workspace/evals/files/v2-profile/profile-config.yml
@@ -1,0 +1,2 @@
+inherits_from: base
+standards_dir: standards

--- a/skills/agent-os-profile-critique/.workspace/evals/files/v2-profile/standards/python-style.md
+++ b/skills/agent-os-profile-critique/.workspace/evals/files/v2-profile/standards/python-style.md
@@ -1,0 +1,12 @@
+# Python Style
+
+We use Python. Always write clean code. Functions should be small and do one thing.
+Variables should have meaningful names. Use type hints when appropriate.
+
+It is important to follow PEP 8. PEP 8 is the style guide for Python code. You should
+read PEP 8 before writing any Python. PEP 8 covers indentation, line length, naming
+conventions, imports, whitespace, comments, and many other topics that are essential
+for writing readable Python code that other developers can maintain.
+
+When writing tests, use pytest. Pytest is a testing framework. Tests should be
+independent and should not rely on each other. Use fixtures for shared setup.

--- a/skills/agent-os-profile-critique/.workspace/evals/results/2026-05-10_205112/results.json
+++ b/skills/agent-os-profile-critique/.workspace/evals/results/2026-05-10_205112/results.json
@@ -1,0 +1,273 @@
+{
+  "exit_reason": "max_iterations (1)",
+  "original_description": "Provides the audit checklists, severity criteria (blocking/warning/suggestion), and artifact patterns needed to properly review Agent OS profiles and standards. Always invoke this skill before auditing - without it you can only give generic feedback, not structured severity-tagged findings. Invoke when the user pastes a standard and asks if it is good or what is wrong with it; when the user asks to review, audit, validate, or critique an agent-os profile or standard; or when the user mentions \"agent-os profile\", \"agent-os standard\", or \"my agent-os setup\" in a review or validation context.",
+  "best_description": "Provides the audit checklists, severity criteria (blocking/warning/suggestion), and artifact patterns needed to properly review Agent OS profiles and standards. Always invoke this skill before auditing - without it you can only give generic feedback, not structured severity-tagged findings. Invoke when the user pastes a standard and asks if it is good or what is wrong with it; when the user asks to review, audit, validate, or critique an agent-os profile or standard; or when the user mentions \"agent-os profile\", \"agent-os standard\", or \"my agent-os setup\" in a review or validation context.",
+  "best_score": "10/15",
+  "best_train_score": "10/15",
+  "best_test_score": null,
+  "final_description": "Provides the audit checklists, severity criteria (blocking/warning/suggestion), and artifact patterns needed to properly review Agent OS profiles and standards. Always invoke this skill before auditing - without it you can only give generic feedback, not structured severity-tagged findings. Invoke when the user pastes a standard and asks if it is good or what is wrong with it; when the user asks to review, audit, validate, or critique an agent-os profile or standard; or when the user mentions \"agent-os profile\", \"agent-os standard\", or \"my agent-os setup\" in a review or validation context.",
+  "iterations_run": 1,
+  "holdout": 0.0,
+  "train_size": 15,
+  "test_size": 0,
+  "history": [
+    {
+      "iteration": 1,
+      "description": "Provides the audit checklists, severity criteria (blocking/warning/suggestion), and artifact patterns needed to properly review Agent OS profiles and standards. Always invoke this skill before auditing - without it you can only give generic feedback, not structured severity-tagged findings. Invoke when the user pastes a standard and asks if it is good or what is wrong with it; when the user asks to review, audit, validate, or critique an agent-os profile or standard; or when the user mentions \"agent-os profile\", \"agent-os standard\", or \"my agent-os setup\" in a review or validation context.",
+      "train_passed": 10,
+      "train_failed": 5,
+      "train_total": 15,
+      "train_results": [
+        {
+          "query": "Here's a standard I wrote for my agent-os profile, is it any good?\n\nAlways use descriptive variable names.",
+          "should_trigger": true,
+          "trigger_rate": 0.3333333333333333,
+          "triggers": 1,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "audit my agent-os profile at ~/agent-os/profiles/my-company/ and give me a severity-tagged report",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "Can you review my agent-os profile and tell me what's wrong?",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "Is this agent-os standard any good?\n\n# Error Handling\n\nAlways handle errors gracefully.",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "Set up a new Node.js project structure with Express and TypeScript",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "I think my agent-os profile has some v2 artifacts in it, can you check?",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "Audit my package.json for outdated dependencies and security issues",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Help me write a coding standard document for our team's React work",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Review this REST API design and tell me where the security holes are",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "How do I configure my .eslintrc.yml for monorepo workspaces?",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Create a config.yml for my GitHub Actions deployment workflow",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "What's the best operating system for running coding agents locally?",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Set up a CI/CD pipeline spec for our staging deployment",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Write me an OpenAPI spec for the /users endpoint",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "How do I customize my GitHub profile README?",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        }
+      ],
+      "test_passed": null,
+      "test_failed": null,
+      "test_total": null,
+      "test_results": null,
+      "passed": 10,
+      "failed": 5,
+      "total": 15,
+      "results": [
+        {
+          "query": "Here's a standard I wrote for my agent-os profile, is it any good?\n\nAlways use descriptive variable names.",
+          "should_trigger": true,
+          "trigger_rate": 0.3333333333333333,
+          "triggers": 1,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "audit my agent-os profile at ~/agent-os/profiles/my-company/ and give me a severity-tagged report",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "Can you review my agent-os profile and tell me what's wrong?",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "Is this agent-os standard any good?\n\n# Error Handling\n\nAlways handle errors gracefully.",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "Set up a new Node.js project structure with Express and TypeScript",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "I think my agent-os profile has some v2 artifacts in it, can you check?",
+          "should_trigger": true,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": false
+        },
+        {
+          "query": "Audit my package.json for outdated dependencies and security issues",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Help me write a coding standard document for our team's React work",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Review this REST API design and tell me where the security holes are",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "How do I configure my .eslintrc.yml for monorepo workspaces?",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Create a config.yml for my GitHub Actions deployment workflow",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "What's the best operating system for running coding agents locally?",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Set up a CI/CD pipeline spec for our staging deployment",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "Write me an OpenAPI spec for the /users endpoint",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        },
+        {
+          "query": "How do I customize my GitHub profile README?",
+          "should_trigger": false,
+          "trigger_rate": 0.0,
+          "triggers": 0,
+          "runs": 3,
+          "pass": true
+        }
+      ]
+    }
+  ]
+}

--- a/skills/agent-os-profile-critique/.workspace/evals/trigger-evals.json
+++ b/skills/agent-os-profile-critique/.workspace/evals/trigger-evals.json
@@ -1,0 +1,77 @@
+[
+  {
+    "query": "Here's a standard I wrote for my agent-os profile, is it any good?\n\nAlways use descriptive variable names.",
+    "should_trigger": true,
+    "notes": "Pasted standard with agent-os context — strongest trigger, Claude has content to evaluate"
+  },
+  {
+    "query": "Can you review my agent-os profile and tell me what's wrong?",
+    "should_trigger": true,
+    "notes": "Profile review request with agent-os keyword"
+  },
+  {
+    "query": "audit my agent-os profile at ~/agent-os/profiles/my-company/ and give me a severity-tagged report",
+    "should_trigger": true,
+    "notes": "Audit with a real path — Claude has something concrete to inspect, avoids the bare-command trap"
+  },
+  {
+    "query": "Is this agent-os standard any good?\n\n# Error Handling\n\nAlways handle errors gracefully.",
+    "should_trigger": true,
+    "notes": "Second pasted-standard variant — no leading context beyond agent-os keyword"
+  },
+  {
+    "query": "I think my agent-os profile has some v2 artifacts in it, can you check?",
+    "should_trigger": true,
+    "notes": "v2 artifact concern — specific enough that Claude should reach for the checklist"
+  },
+  {
+    "query": "Set up a new Node.js project structure with Express and TypeScript",
+    "should_trigger": false,
+    "notes": "General project scaffolding, no Agent OS context"
+  },
+  {
+    "query": "Audit my package.json for outdated dependencies and security issues",
+    "should_trigger": false,
+    "notes": "Audit keyword but unrelated to Agent OS"
+  },
+  {
+    "query": "Help me write a coding standard document for our team's React work",
+    "should_trigger": false,
+    "notes": "Standard keyword but no Agent OS context, generic team doc"
+  },
+  {
+    "query": "How do I configure my .eslintrc.yml for monorepo workspaces?",
+    "should_trigger": false,
+    "notes": "Config file question but unrelated tool"
+  },
+  {
+    "query": "Review this REST API design and tell me where the security holes are",
+    "should_trigger": false,
+    "notes": "Review keyword but API design domain, not Agent OS"
+  },
+  {
+    "query": "What's the best operating system for running coding agents locally?",
+    "should_trigger": false,
+    "notes": "Literal 'operating system' near-miss for 'agent os'"
+  },
+  {
+    "query": "Create a config.yml for my GitHub Actions deployment workflow",
+    "should_trigger": false,
+    "notes": "config.yml near-miss, wrong product context"
+  },
+  {
+    "query": "Write me an OpenAPI spec for the /users endpoint",
+    "should_trigger": false,
+    "notes": "Spec keyword but OpenAPI, not Agent OS"
+  },
+  {
+    "query": "How do I customize my GitHub profile README?",
+    "should_trigger": false,
+    "notes": "Profile keyword in unrelated context"
+  },
+  {
+    "query": "Set up a CI/CD pipeline spec for our staging deployment",
+    "should_trigger": false,
+    "notes": "Spec plus setup keywords but DevOps domain, not Agent OS"
+  }
+]

--- a/skills/agent-os-profile-critique/.workspace/run-trigger-eval.sh
+++ b/skills/agent-os-profile-critique/.workspace/run-trigger-eval.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Isolated trigger eval for agent-os-expert.
+#
+# 1. Moves ~/.claude to ~/.claude-back (atomic rename)
+# 2. Builds a minimal ~/.claude with only auth files
+# 3. Smoke-tests auth before wasting time on a broken run
+# 4. Runs the trigger eval
+# 5. Restores ~/.claude — always, even on error or ctrl-c
+set -euo pipefail
+
+CLAUDE_DIR="$HOME/.claude"
+BACKUP_DIR="$HOME/.claude-back"
+SCRIPT_DIR="$HOME/.claude-back/skills/create-a-skill"
+
+WORKSPACE_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_EVAL_SET="$WORKSPACE_DIR/evals/trigger-evals.json"
+SKILL_PATH="$(cd "$WORKSPACE_DIR/.." && pwd)"
+RESULTS_DIR="$WORKSPACE_DIR/evals/results"
+
+# ── restore ────────────────────────────────────────────────────────────────────
+
+restore() {
+    echo ""
+    echo "==> Restoring ~/.claude ..."
+    rm -rf "$CLAUDE_DIR"
+    mv "$BACKUP_DIR" "$CLAUDE_DIR"
+    echo "    Done."
+}
+
+trap restore EXIT
+
+# ── guard: nothing left behind from a previous crashed run ────────────────────
+
+if [ -d "$BACKUP_DIR" ]; then
+    echo "ERROR: $BACKUP_DIR already exists — a previous run may not have restored cleanly."
+    echo "       If ~/.claude looks correct, remove $BACKUP_DIR and retry."
+    exit 1
+fi
+
+# ── move ~/.claude aside ──────────────────────────────────────────────────────
+
+echo "==> Moving ~/.claude to ~/.claude-back ..."
+mv "$CLAUDE_DIR" "$BACKUP_DIR"
+echo "    Done."
+
+# ── build minimal ~/.claude with auth only ────────────────────────────────────
+
+echo ""
+echo "==> Building minimal ~/.claude (auth only) ..."
+mkdir -p "$CLAUDE_DIR"
+for dir in sessions config statsig; do
+    if [ -d "$BACKUP_DIR/$dir" ]; then
+        cp -R "$BACKUP_DIR/$dir" "$CLAUDE_DIR/$dir"
+        echo "  copied: $dir"
+    else
+        echo "  not found, skipping: $dir"
+    fi
+done
+
+# ── smoke-test auth ───────────────────────────────────────────────────────────
+
+echo ""
+echo "==> Smoke-testing auth (claude -p 'say: ok') ..."
+if ! claude -p "say: ok" --output-format text > /dev/null 2>&1; then
+    echo "ERROR: auth check failed — claude -p could not authenticate."
+    echo "       Check that sessions/, config/, or statsig/ contain valid credentials."
+    exit 1
+fi
+echo "    Auth OK."
+
+# ── run eval ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "==> Running trigger eval (1 iteration, no holdout) ..."
+PYTHONPATH="$SCRIPT_DIR" python3 -m scripts.run_loop \
+    --eval-set "$SKILL_EVAL_SET" \
+    --skill-path "$SKILL_PATH" \
+    --model claude-sonnet-4-6 \
+    --max-iterations 1 \
+    --holdout 0 \
+    --verbose \
+    --report none \
+    --results-dir "$RESULTS_DIR" \
+    | tee /tmp/eval-results-latest.json
+
+# Print terminal summary and update EVAL-REPORT.md
+LATEST=$(ls -td "$RESULTS_DIR"/* 2>/dev/null | head -1)
+if [ -n "$LATEST" ] && [ -f "$LATEST/results.json" ]; then
+    echo ""
+    echo "========================================"
+    echo " TRIGGER EVAL SUMMARY"
+    echo "========================================"
+    python3 - "$LATEST/results.json" "$WORKSPACE_DIR/EVAL-REPORT.md" <<'PYEOF'
+import json, sys, re
+from datetime import date
+
+data = json.load(open(sys.argv[1]))
+report_path = sys.argv[2]
+iteration = data["history"][0]
+results = iteration["train_results"]
+
+pos = [r for r in results if r["should_trigger"]]
+neg = [r for r in results if not r["should_trigger"]]
+tp = sum(r["triggers"] for r in pos)
+pos_runs = sum(r["runs"] for r in pos)
+fp = sum(r["triggers"] for r in neg)
+neg_runs = sum(r["runs"] for r in neg)
+tn = neg_runs - fp
+fn = pos_runs - tp
+precision = tp / (tp + fp) if (tp + fp) > 0 else 1.0
+recall    = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+accuracy  = (tp + tn) / (tp + tn + fp + fn)
+
+# Terminal output
+print(f" Score:     {iteration['train_passed']}/{iteration['train_total']}")
+print(f" Precision: {precision:.0%}  (of triggers, how many were correct)")
+print(f" Recall:    {recall:.0%}  (of positives, how many fired)")
+print(f" Accuracy:  {accuracy:.0%}")
+print()
+print(" SHOULD TRIGGER:")
+for r in pos:
+    mark = "PASS" if r["pass"] else "FAIL"
+    print(f"  [{mark}] {r['triggers']}/{r['runs']}  {r['query'][:72]}")
+print()
+print(" SHOULD NOT TRIGGER:")
+for r in neg:
+    mark = "PASS" if r["pass"] else "FAIL"
+    print(f"  [{mark}] {r['triggers']}/{r['runs']}  {r['query'][:72]}")
+print()
+print(f" Results saved to: {sys.argv[1]}")
+
+# Build markdown results block
+fn_list = [r for r in pos if not r["pass"]]
+fp_list = [r for r in neg if not r["pass"]]
+
+lines = [f"**Run {date.today()} — isolated, no competing skills**", ""]
+lines += [f"- **Score:** {iteration['train_passed']} / {iteration['train_total']}"]
+lines += [f"- **Precision:** {precision:.0%}"]
+lines += [f"- **Recall:** {recall:.0%}"]
+lines += [f"- **Accuracy:** {accuracy:.0%}"]
+
+if fn_list:
+    lines += ["- **False negatives (should-trigger, did not fire):**"]
+    for r in fn_list:
+        lines += [f"  - {r['query']}"]
+else:
+    lines += ["- **False negatives:** none"]
+
+if fp_list:
+    lines += ["- **False positives (should not trigger, fired anyway):**"]
+    for r in fp_list:
+        lines += [f"  - {r['query']}"]
+else:
+    lines += ["- **False positives:** none"]
+
+lines += [f"- **Decision:** _update after review_"]
+block = "\n".join(lines)
+
+# Replace the results section in EVAL-REPORT.md
+report = open(report_path).read()
+pattern = r'(### Trigger eval results\n)(.*?)(\n## Functional evals)'
+replacement = r'\1\n' + block + r'\n\3'
+updated = re.sub(pattern, replacement, report, flags=re.DOTALL)
+open(report_path, "w").write(updated)
+print(f" EVAL-REPORT.md updated.")
+PYEOF
+    echo "========================================"
+fi

--- a/skills/agent-os-profile-critique/LICENSE
+++ b/skills/agent-os-profile-critique/LICENSE
@@ -1,0 +1,37 @@
+MIT License
+
+Copyright (c) 2026 Philip A Senger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## Third-Party Attribution
+
+This skill describes and helps users work with **Agent OS**, a project by
+CasJam Media LLC (Builder Methods). Agent OS itself is a separate work and is
+not redistributed here.
+
+Upstream project: https://github.com/buildermethods/agent-os
+Upstream copyright: Copyright (c) 2025 CasJam Media LLC (Builder Methods)
+Upstream license: MIT
+
+"Agent OS" and "Builder Methods" are credited to their respective owners.
+This skill is an independent work and is not affiliated with, endorsed by,
+or sponsored by CasJam Media LLC or Builder Methods.

--- a/skills/agent-os-profile-critique/SKILL.md
+++ b/skills/agent-os-profile-critique/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: agent-os-profile-critique
+description: Provides the audit checklists, severity criteria (blocking/warning/suggestion), and artifact patterns needed to properly review Agent OS profiles and standards. Always invoke this skill before auditing - without it you can only give generic feedback, not structured severity-tagged findings. Invoke when the user pastes a standard and asks if it is good or what is wrong with it; when the user asks to review, audit, validate, or critique an agent-os profile or standard; or when the user mentions "agent-os profile", "agent-os standard", or "my agent-os setup" in a review or validation context.
+allowed-tools: Read, Grep, Glob, Bash, Write, Edit
+license: MIT
+---
+
+# Agent OS Profile Critique
+
+Audit and critique Agent OS v3 profiles and standards. Produce severity-tagged findings with concrete fixes.
+
+## How to use the references
+
+Read on demand. Do not preload.
+
+| If the user is asking about... | Read |
+|---|---|
+| Conducting a review or audit | `references/review-checklists.md` |
+| Writing standards, index.yml, quality | `references/standards.md` |
+| File layout, what a valid profile looks like | `references/file-structure.md` |
+| Migrating from v2, flagging v2 artifacts | `references/v2-vs-v3.md` |
+| Profile structure, inheritance | `references/profiles.md` |
+| Standards vs Skills distinction | `references/standards-vs-skills.md` |
+
+## Version awareness
+
+Before giving substantive guidance, read `~/agent-os/config.yml` and check the `version:` field.
+
+- If `3.x`: proceed normally.
+- `4.x` or higher: tell the user once that this skill is calibrated to v3 and may be out of date. Ask whether to proceed. If yes, caveat any v3-specific claim as "v3 behavior, may have changed in v4".
+- Missing or below `3.0.0`: treat as a v2 install. See `references/v2-vs-v3.md` and recommend migration.
+
+Do not refuse to help on a version mismatch.
+
+## Audit workflow
+
+1. Confirm the target: a profile directory (`~/agent-os/profiles/<name>/`), a project's `agent-os/` folder, or a pasted standard file.
+2. Read what exists before recommending changes. Run `ls`, read `index.yml`, sample a few standards files.
+3. Pull the relevant reference from the table above.
+4. Produce a findings list. Each finding must include:
+   - Severity: `blocking`, `warning`, or `suggestion`
+   - Specific file path and line (if applicable)
+   - Concrete fix
+
+Always flag v2 artifacts on sight. See `references/v2-vs-v3.md`.
+
+## Use the right checklist
+
+Read `references/review-checklists.md` and apply:
+- Profile review: auditing `~/agent-os/profiles/<name>/`
+- Project setup review: auditing a repo's `agent-os/` and `.claude/commands/agent-os/`
+- Standards quality audit: line-by-line review of a standard file
+
+## Quality bar for standards
+
+A standard earns its place in the context window only if it teaches something non-obvious. Flag standards that:
+- Restate framework defaults
+- Describe what the code itself already shows
+- Run on for paragraphs without code examples
+- Combine multiple unrelated concepts
+
+A standard is good when:
+- It leads with the rule on line 1
+- Includes a code example
+- Documents an opinionated, tribal, or easy-to-get-wrong pattern
+- Fits on one screen
+
+See `references/standards.md` for full quality rules and examples.
+
+## Don't
+
+- Don't guess paths. Verify with `ls` before referencing them.
+- Don't suggest `profile-config.yml`. That is a v2 artifact.
+- Don't recommend installing subagents under `.claude/agents/agent-os/`. That is a v2 artifact.
+- Don't generate boilerplate standards for things every framework already does.
+
+> Agent OS is a project by CasJam Media LLC (Builder Methods): https://github.com/buildermethods/agent-os. See `LICENSE` for attribution.

--- a/skills/agent-os-profile-critique/references/file-structure.md
+++ b/skills/agent-os-profile-critique/references/file-structure.md
@@ -1,0 +1,75 @@
+# File Structure
+
+Agent OS lives in two places: a **base installation** on the machine and a **project installation** in each repo.
+
+## Base installation `~/agent-os/`
+
+```
+~/agent-os/
+  commands/
+    agent-os/                   # 5 slash command .md files (source)
+      discover-standards.md
+      index-standards.md
+      inject-standards.md
+      plan-product.md
+      shape-spec.md
+  profiles/
+    <profile-name>/
+      standards/                # .md standards files only. No profile-config.yml in v3.
+  scripts/
+    project-install.sh
+    sync-to-profile.sh
+    common-functions.sh
+  config.yml                    # version, default_profile, profiles: (inheritance)
+```
+
+## Project installation `your-project/`
+
+```
+your-project/
+  agent-os/
+    standards/
+      <domain>/
+        <standard>.md
+      index.yml                 # Index for matching
+    specs/
+      YYYY-MM-DD-HHMM-<slug>/
+        plan.md
+        shape.md
+        standards.md
+        references.md
+        visuals/
+    product/
+      mission.md
+      roadmap.md
+      tech-stack.md
+  .claude/
+    commands/
+      agent-os/                 # 5 slash command .md files (copied from base)
+        discover-standards.md
+        index-standards.md
+        inject-standards.md
+        plan-product.md
+        shape-spec.md
+```
+
+## What to commit
+
+| Path | Commit? | Reason |
+|---|---|---|
+| `agent-os/standards/` | Yes | Share conventions with the team |
+| `agent-os/product/` | Yes | Share product context |
+| `agent-os/specs/` | Yes | Preserve project history |
+| `.claude/commands/agent-os/` | Optional | Team can regenerate from base install with `--commands-only` |
+
+`.claude/commands/agent-os/` is a copy of the source commands; some teams prefer to commit it for reproducibility, others gitignore it.
+
+## Things that should NOT exist in v3
+
+If you see any of these, flag them as v2 leftovers:
+
+- `.claude/agents/agent-os/` (subagents, retired)
+- `~/agent-os/profiles/<name>/profile-config.yml` (inheritance moved to `config.yml`)
+- `~/agent-os/profiles/<name>/agents/`
+- `~/agent-os/profiles/<name>/commands/`
+- `~/agent-os/profiles/<name>/workflows/`

--- a/skills/agent-os-profile-critique/references/profiles.md
+++ b/skills/agent-os-profile-critique/references/profiles.md
@@ -1,0 +1,63 @@
+# Profiles
+
+A **profile** is a named folder under `~/agent-os/profiles/<name>/` containing a `standards/` subfolder of `.md` files.
+
+## Rules
+
+- Any directory under `~/agent-os/profiles/` containing `standards/` is a valid profile. No registration step.
+- The `profiles:` section in `~/agent-os/config.yml` only declares **inheritance**. Omitting a profile from `config.yml` means it stands alone.
+- When inheriting, child profiles override parents file-by-file: same filename in both → child wins.
+- Profiles in v3 contain **only `standards/`**. No `agents/`, no `commands/`, no `workflows/`, no `profile-config.yml`.
+
+## config.yml format
+
+```yaml
+version: 3.0.0
+default_profile: my-rails-app
+profiles:
+  my-rails-app:
+    inherits_from: rails-base
+  rails-base:
+    inherits_from: ruby-general
+```
+
+Three-level inheritance is fine; deeper chains start to be a smell.
+
+## Common naming patterns
+
+- **By tech stack:** `rails`, `nextjs`, `django`, `go-services`
+- **By client:** `client-acme`, `client-xyz`
+- **By context:** `work`, `personal`, `consulting`
+
+Pick one axis and stick with it. Mixing axes (`rails` next to `client-acme`) leads to confusion about which profile to pick for a new project.
+
+## When to create a new profile vs. extend an existing one
+
+Create a **new profile** when:
+- The tech stack is materially different
+- A client requires standards that conflict with your defaults
+- You want a clean slate for experimentation
+
+Extend (inherit from) an existing profile when:
+- 70%+ of standards would be the same
+- You only need to override a handful of conventions
+- You want upstream changes to flow down
+
+## Sharing profiles with a team
+
+Three workable patterns:
+1. **Commit `agent-os/standards/` per project.** Lowest setup cost, but duplication across repos.
+2. **Shared profile name.** Every team member maintains the same profile name locally; sync via `sync-to-profile.sh`.
+3. **Dedicated standards repo.** Clone into `~/agent-os/profiles/<name>/` and treat the profile as a versioned artifact.
+
+Pattern 3 scales best for organizations.
+
+## Auditing a profile
+
+When asked to review `~/agent-os/profiles/<name>/`:
+
+1. Confirm `standards/` exists with `.md` files
+2. Flag any v2 artifacts (`agents/`, `commands/`, `workflows/`, `profile-config.yml`)
+3. Read `~/agent-os/config.yml`. Verify `version: 3.0.0`; if `inherits_from` is set, verify the parent folder exists.
+4. Apply the standards quality rules (see `standards.md`)
+5. Flag standards that document obvious framework behavior

--- a/skills/agent-os-profile-critique/references/review-checklists.md
+++ b/skills/agent-os-profile-critique/references/review-checklists.md
@@ -1,0 +1,69 @@
+# Review Checklists
+
+Use the relevant checklist below. For each finding, report: **severity** (blocking / warning / suggestion), **location** (file path or line), and a **concrete fix**.
+
+## Profile review: `~/agent-os/profiles/<name>/`
+
+1. Confirm `standards/` exists with `.md` files.
+2. Flag v2 artifacts: `agents/`, `commands/`, `workflows/`, `profile-config.yml` (see `v2-vs-v3.md`).
+3. Read `~/agent-os/config.yml`:
+   - `version: 3.0.0`?
+   - If `inherits_from` is declared, does the parent profile folder exist?
+   - Is `default_profile` set to a profile that exists?
+4. For each standard:
+   - Does it lead with the rule on line 1?
+   - Is it concise (bullets, not paragraphs)?
+   - Are there code examples where useful?
+   - Does it document something non-obvious / tribal / opinionated?
+5. Flag standards that describe obvious framework behavior or restate what the code already shows.
+
+## Project setup review: `<repo>/`
+
+1. Confirm `agent-os/standards/` exists with `.md` files.
+2. Confirm `agent-os/standards/index.yml` exists. Cross-check:
+   - Every entry maps to an existing file (flag orphans)
+   - Every standards file has an entry (flag unindexed files)
+3. Confirm `.claude/commands/agent-os/` has all 5 files:
+   - `discover-standards.md`
+   - `index-standards.md`
+   - `inject-standards.md`
+   - `plan-product.md`
+   - `shape-spec.md`
+4. Flag `.claude/agents/agent-os/` if present (v2 artifact).
+5. If `agent-os/product/` exists, verify all three: `mission.md`, `roadmap.md`, `tech-stack.md`.
+6. If `agent-os/specs/` has entries, verify each spec folder contains at minimum `plan.md` and `shape.md`.
+
+## Standards quality audit
+
+For each `.md` file in `agent-os/standards/`:
+
+1. Read the file end-to-end.
+2. Apply quality rules from `standards.md`. Flag:
+   - Paragraph-heavy content with no code
+   - Missing code examples
+   - Single-concept violations (multiple unrelated patterns)
+   - Documents framework defaults
+   - Vague filename (e.g. `general.md`, `misc.md`)
+3. Check `index.yml`:
+   - Descriptions specific enough to drive `/inject-standards` matching?
+   - Any orphan entries?
+   - Any unindexed files?
+4. Provide concrete rewrite suggestions, not generic advice. When you flag a paragraph, supply the rewritten version.
+
+## Output format for findings
+
+Group by severity:
+
+```
+## Blocking
+- `agent-os/standards/index.yml:14`: entry `api/legacy` references deleted file.
+  Fix: run `/index-standards`.
+
+## Warning
+- `agent-os/standards/error-handling.md`: 3 paragraphs of philosophy, no code example.
+  Fix: rewrite leading with the rule plus a JSON example. Suggested draft: <inline>.
+
+## Suggestion
+- `agent-os/standards/naming.md` (180 lines): combines file naming, class naming, env vars.
+  Fix: split into 3 files.
+```

--- a/skills/agent-os-profile-critique/references/standards-vs-skills.md
+++ b/skills/agent-os-profile-critique/references/standards-vs-skills.md
@@ -1,0 +1,42 @@
+# Standards vs Skills
+
+Standards and Skills solve different problems. Use the right tool, and compose them when both apply.
+
+## Comparison
+
+| | Standards | Skills |
+|---|---|---|
+| **Type** | Declarative: what conventions | Procedural: how to do tasks |
+| **Location** | `agent-os/standards/` | `.claude/skills/` |
+| **Invocation** | Explicit via `/inject-standards` (or auto-suggest from `index.yml`) | Auto-detected by Claude from skill descriptions |
+| **Loaded** | Only when injected | Description always in context; body when triggered |
+| **Best for** | "We use X envelope for API responses" | "When making a PDF report, do steps 1–5" |
+
+## Use `/inject-standards` when
+
+- You want explicit control over which conventions apply
+- The work spans multiple domains (API + DB + naming)
+- You're authoring a Skill and want to bake in conventions
+
+## Use Skills when
+
+- There's a repeatable procedure to automate
+- You want auto-detection ("when the user mentions X, do Y")
+- The task is self-contained with clear inputs and outputs
+
+## Best pattern: compose them
+
+A Skill provides the procedure; standards provide the conventions. The Skill `@`-references the standards files so they stay current:
+
+```markdown
+Before implementing, read:
+- @agent-os/standards/api/response-format.md
+- @agent-os/standards/api/error-handling.md
+```
+
+This combination gives:
+- **Procedural automation** from the Skill (the *how*)
+- **Declarative conventions** from the Standards (the *what*)
+- **Single source of truth.** When standards change, the Skill picks up the new content automatically.
+
+If a Skill is bundled or distributed externally and can't rely on a project's standards being present, embed the content instead of referencing it. `/inject-standards` will offer this choice when invoked inside Skill creation.

--- a/skills/agent-os-profile-critique/references/standards.md
+++ b/skills/agent-os-profile-critique/references/standards.md
@@ -1,0 +1,112 @@
+# Standards
+
+Standards are **declarative documentation of coding conventions**: patterns and rules, not step-by-step procedures.
+
+Examples of valid standards content:
+- "All API responses use this envelope structure"
+- "Error codes follow this naming convention"
+- "Database migrations must include rollback logic"
+
+## Layout
+
+```
+agent-os/standards/
+├── api/
+│   ├── response-format.md
+│   └── error-handling.md
+├── database/
+│   └── migrations.md
+├── naming-conventions.md       # Root-level standard
+└── index.yml
+```
+
+## index.yml format
+
+```yaml
+api:
+  response-format:
+    description: API response envelope structure, status codes
+  error-handling:
+    description: Error code conventions, exception handling
+root:
+  naming-conventions:
+    description: File, class, and variable naming conventions
+```
+
+`root` is a reserved keyword for standards files at the top level of `agent-os/standards/` (not inside subfolders).
+
+### What makes a good description
+
+The description is what `/inject-standards` uses for auto-matching. Vague descriptions break matching.
+
+- **Bad:** `description: API stuff`
+- **Good:** `description: API response envelope structure, status codes, success/error keys`
+
+Include the specific concepts and keywords that would appear in a conversation about this topic.
+
+## Quality rules: when a standard earns its keep
+
+Standards consume context-window tokens every time they're injected. Each one must pay rent.
+
+**Write a standard for:**
+- Patterns that are unusual or unconventional
+- Opinionated choices that could have gone differently
+- Tribal knowledge a new developer wouldn't know without being told
+- Things people frequently get wrong
+
+**Do NOT write a standard for:**
+- Standard framework patterns (e.g., "controllers go in `app/controllers/`" in Rails)
+- Universally obvious best practices
+- Things that the code already makes clear at a glance
+
+## Writing style
+
+- **Lead with the rule.** State what to do, then why.
+- **Use code examples.** Show, don't tell.
+- **Bullets over paragraphs.** Scannable beats readable.
+- **One concept per file.** Don't combine unrelated patterns.
+
+## Good example
+
+````markdown
+# Error Responses
+
+Use error codes: `AUTH_001`, `DB_001`, `VAL_001`.
+
+```json
+{ "success": false, "error": { "code": "AUTH_001", "message": "..." } }
+```
+
+- Always include both code and message
+- Log full error server-side, return safe message to client
+````
+
+Why this works: rule on line 1, example immediately, three bullets cover the operational nuance, fits on a screen.
+
+## Bad example
+
+```markdown
+# Error Handling Guidelines
+
+When an error occurs in our application, we have established a consistent
+pattern for how errors should be formatted. This document describes the
+philosophy behind our approach...
+[continues for 3 more paragraphs with no code example]
+```
+
+Why it fails: no rule on line 1, no code example, paragraph-heavy, philosophical filler.
+
+## Common audit findings
+
+When critiquing a standards collection, look for:
+
+| Finding | Severity | Fix |
+|---|---|---|
+| Paragraph-heavy with no code | Warning | Rewrite leading with the rule + example |
+| Documents framework defaults | Blocking | Delete |
+| Multiple unrelated concepts in one file | Warning | Split into separate files |
+| index.yml description too vague | Warning | Rewrite with specific keywords |
+| Orphan index.yml entry (file deleted) | Blocking | Run `/index-standards` |
+| Standards file not in index.yml | Blocking | Run `/index-standards` |
+| File over ~100 lines | Suggestion | Likely combining concepts; split |
+| No code examples anywhere in collection | Warning | Add examples to top 3 most-used standards first |

--- a/skills/agent-os-profile-critique/references/v2-vs-v3.md
+++ b/skills/agent-os-profile-critique/references/v2-vs-v3.md
@@ -1,0 +1,48 @@
+# v2 vs v3
+
+Agent OS v3 was released January 2026. The differences below matter for migration and for spotting v2 artifacts during a review.
+
+## Key differences
+
+| Area | v2 | v3 |
+|---|---|---|
+| Subagents | `.claude/agents/agent-os/` installed | Retired. Frontier models handle it |
+| Spec writing | Dedicated implementation commands | Plan mode + `/shape-spec` |
+| Profile inheritance | `profile-config.yml` inside each profile | `config.yml` at `~/agent-os/` root |
+| Standards discovery | Manual | `/discover-standards` |
+| Index maintenance | Manual | `/index-standards` |
+| Profile sync | Manual copy | `~/agent-os/scripts/sync-to-profile.sh` |
+| Profile contents | `standards/`, `agents/`, `commands/`, `workflows/` | `standards/` only |
+
+## Migrating from v2
+
+1. Remove v2 artifacts:
+   ```bash
+   rm -rf .claude/agents/agent-os/
+   rm -rf .claude/commands/agent-os/
+   ```
+2. Reinstall v3 commands without disturbing standards:
+   ```bash
+   ~/agent-os/scripts/project-install.sh --commands-only
+   ```
+3. Move inheritance config from per-profile `profile-config.yml` files into the root `~/agent-os/config.yml`:
+   ```yaml
+   version: 3.0.0
+   default_profile: my-app
+   profiles:
+     my-app:
+       inherits_from: rails-base
+   ```
+4. Delete the `profile-config.yml` files and any `agents/` / `commands/` / `workflows/` subdirs inside each profile.
+5. Standards files, specs, and product docs transfer **without modification**.
+
+## How to spot a v2 install during a review
+
+Any of these is a v2 leftover:
+
+- A `profile-config.yml` anywhere under `~/agent-os/profiles/`
+- `agents/`, `commands/`, or `workflows/` subdirs inside a profile
+- `.claude/agents/agent-os/` in a project
+- `~/agent-os/config.yml` missing or with `version` below `3.0.0`
+
+When you see these, recommend the migration steps above before doing any other audit work. Most other findings depend on a clean v3 baseline.

--- a/skills/create-a-skill/README.md
+++ b/skills/create-a-skill/README.md
@@ -1,0 +1,99 @@
+# create-a-skill
+
+Scripts for building, evaluating, and optimizing Claude Code skills.
+
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `run_eval.py` | Run a trigger evaluation against a skill description |
+| `run_loop.py` | Run the eval + improve loop until all pass or max iterations |
+| `improve_description.py` | Call Claude to improve a description based on eval results |
+| `generate_report.py` | Generate an HTML report from eval results |
+| `aggregate_benchmark.py` | Aggregate benchmark results across multiple runs |
+| `quick_validate.py` | Quick validation of a skill structure |
+| `package_skill.py` | Package a skill for distribution |
+| `utils.py` | Shared utilities (SKILL.md parsing) |
+
+---
+
+## How an eval works
+
+### What the subprocess does
+
+Each query fires a `claude -p <query>` subprocess in a worker process. The subprocess:
+
+- Runs with `cwd=project_root` (the nearest ancestor directory containing `.claude/`)
+- Strips only `CLAUDECODE` from the environment; everything else, including auth, is inherited
+- Passes `--include-partial-messages` to receive streaming events for early exit
+
+### Model loaded
+
+- In `run_loop.py`, `--model` is **required**, so always explicit
+- In `run_eval.py` standalone, `--model` is **optional** (defaults to `None`, meaning the user's configured model)
+- The same model is used for both eval subprocesses and `improve_description` calls
+- There is no model pinning or isolation; the eval inherits whatever Claude Code defaults are active
+
+### Skills, commands, and context
+
+The subprocess is not isolated. It loads the full Claude Code environment at `project_root`:
+
+- All installed skills in `.claude/skills/` are present
+- All existing commands in `.claude/commands/` are present
+- The test skill is injected as one additional command file: `.claude/commands/{skill_name}-skill-{uuid8}.md`
+- `settings.local.json` is loaded, including all `permissions.allow` entries
+- Both the global `~/.claude/CLAUDE.md` and any project-level `CLAUDE.md` are loaded
+
+The test skill must compete against all real installed skills. This is intentional (it simulates real usage), but it means **results change as you add or remove skills**, and two skills with overlapping descriptions will interfere with each other.
+
+### Profiles
+
+No isolation. Whatever profiles are configured in the project's `.claude/` directory are active in each subprocess.
+
+### Trigger detection
+
+The eval watches the stream for a `content_block_start` event of type `tool_use`. If the tool name is `Skill` or `Read`, it accumulates the streaming JSON and checks whether the unique test skill name appears in it. If it does, the query is counted as triggered.
+
+If the first tool call is anything other than `Skill` or `Read`, the subprocess is killed and the query is counted as not triggered.
+
+---
+
+## Known issues
+
+### Premature `return False` on non-Skill tool calls (`run_eval.py`)
+
+```python
+if tool_name in ("Skill", "Read"):
+    pending_tool_name = tool_name
+    accumulated_json = ""
+else:
+    return False  # kills the process immediately
+```
+
+If Claude's first tool call is anything other than `Skill` or `Read` (e.g., it calls `Bash` or `WebSearch` before triggering the skill), this immediately returns `False` and kills the process. The intent — if Claude does not immediately invoke the skill, it did not trigger — is defensible for trigger-detection purposes. However, if Claude chains tools and does something minor before calling the skill, this will misclassify that as a miss.
+
+### `|` block scalar joined with spaces instead of newlines (`utils.py`)
+
+```python
+description = " ".join(continuation_lines)
+```
+
+For a YAML `|` (literal block scalar), lines should be joined with `\n`, not space. For `>` (folded), space is correct. The code uses space regardless of which scalar indicator was used. In practice this only matters if a description has intentional multi-line content, but the logic is wrong.
+
+### `improve_description` subprocess does not set `cwd`
+
+The eval subprocess uses `cwd=project_root`, but the `_call_claude` call inside `improve_description.py` does not specify `cwd`. They run from different directories and therefore see different contexts. For improvement this is harmless (it is pure text generation with no tool use), but it is an inconsistency.
+
+### No model pinning for eval subprocesses
+
+The eval subprocess model and the improvement model share the same CLI argument, but the subprocess does not receive a `--model` flag unless the caller passes one. If `run_eval.py` is invoked without `--model`, each subprocess uses the user's configured default. Eval results from one machine or session may not reproduce on another if the default model differs.
+
+### Parallel workers write to the same `.claude/commands/` directory
+
+With 10 workers, 10 command files are created simultaneously. File names are unique (UUID suffix) so there are no collisions, and `exist_ok=True` on `mkdir` prevents races. Cleanup is in `finally` blocks so it is reliable. If a worker crashes hard enough to skip `finally`, leftover command files will remain.
+
+---
+
+## Design notes
+
+The eval is a "does Claude pick this skill over all other currently-installed skills" test, not a clean-room isolation test. That is a deliberate design choice for real-world accuracy: the skill description must stand out among whatever is actually installed. The tradeoff is that results are coupled to the current state of your skill installation.


### PR DESCRIPTION
## What

Adds two new skills for Agent OS v3 users:
- **agent-os-assist** — reference skill covering installation, slash commands, profiles, standards, and ticket-to-spec workflows
- **agent-os-profile-critique** — audit skill that produces severity-tagged findings (blocking, warning, suggestion) against v3 conventions

## Why

Closes #21 — users working with Agent OS v3 had no skill to guide bootstrap, audit, or ticket-to-spec workflows. Both skills include trigger evals and workspace eval infrastructure.

## Type of Change

- [x] New skill

## Skill Checklist

- [x] `SKILL.md` has valid YAML frontmatter (`name`, `description`, `allowed-tools`)
- [x] `name` is lowercase-hyphenated and matches the directory name
- [x] `description` is written in third person with trigger words
- [x] Reference files are in `references/` (one level deep)
- [x] `SKILL.md` is under 500 lines
- [x] No secrets, credentials, or PII committed
- [x] `.claude-plugin/marketplace.json` updated (if new skill)
- [x] `README.md` skills table updated (if new skill)

## Testing

- [ ] Tested locally by invoking the skill with a realistic prompt
- [ ] Verified the skill activates correctly (not confused with another skill)

Closes #21