### PR TITLE
docs(code-of-conduct): fix broken enforcement contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CODE_OF_CONDUCT** — Replace broken "issue." placeholder with a link to open a GitHub issue so reporters have a real, reachable enforcement contact. ([#35](https://github.com/psenger/ai-agent-skills/issues/35))
+
 ## [2.1.0] - 2026-05-16
 
 ### Added

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-issue.
+reported to the community leaders responsible for enforcement by opening
+a GitHub issue at https://github.com/psenger/ai-agent-skills/issues/new.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
## Summary

- Replace the broken placeholder "issue." at line 63 of `CODE_OF_CONDUCT.md` with a link to open a GitHub issue, giving reporters a real, reachable enforcement channel.
- The existing privacy clause already obligates maintainers to keep reporter identity confidential.

## Ticket

[#35](https://github.com/psenger/ai-agent-skills/issues/35)

## Changes

- `CODE_OF_CONDUCT.md` — enforcement contact updated from placeholder to `https://github.com/psenger/ai-agent-skills/issues/new`
- `CHANGELOG.md` — Fixed entry added under `[Unreleased]`

## Test Plan

- [ ] Verify line 63 of `CODE_OF_CONDUCT.md` links to the GitHub issues URL
- [ ] Confirm the link opens the new-issue form on the repo

## Changelog

- **CODE_OF_CONDUCT** — Replace broken "issue." placeholder with a link to open a GitHub issue so reporters have a real, reachable enforcement contact. ([#35](https://github.com/psenger/ai-agent-skills/issues/35))