### PR TITLE
docs(security): replace placeholder content with real policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **SECURITY** — Replace GitHub placeholder template with a real security policy: correct supported-versions table (v2.x), private vulnerability reporting via GitHub Security Advisories, response timeline, coordinated disclosure process, and scope statement. ([#34](https://github.com/psenger/ai-agent-skills/issues/34))
+
 ## [2.1.1] - 2026-05-16
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,50 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+Only the latest release on `main` receives security fixes. Older versions are not patched.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| 2.x (latest) | :white_check_mark: |
+| < 2.0   | :x:                |
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+**Do not open a public GitHub issue for security vulnerabilities.**
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Use GitHub's private vulnerability reporting to submit a report confidentially:
+
+**[Report a vulnerability](https://github.com/psenger/ai-agent-skills/security/advisories/new)**
+
+Your report is visible only to the maintainer. Include as much detail as you can:
+- Which skill or file is affected
+- Steps to reproduce or demonstrate the issue
+- Potential impact
+
+## Response Timeline
+
+| Milestone | Target |
+| --------- | ------ |
+| Acknowledgement | Within 5 business days |
+| Triage and severity assessment | Within 10 business days |
+| Fix or mitigation | Dependent on severity and complexity |
+
+## Disclosure Process
+
+1. You submit a private advisory — only the maintainer can see it.
+2. The maintainer acknowledges receipt and assesses severity.
+3. A fix is developed and tested privately.
+4. A patched release is published to `main`.
+5. The advisory is published (coordinated disclosure). You will be credited unless you prefer to remain anonymous.
+
+## Scope
+
+**In scope:**
+- SKILL.md files shipped in this repository
+- Skill scripts and reference files under `skills/`
+- The `.claude-plugin/marketplace.json` manifest
+
+**Out of scope:**
+- Skills installed from this repo into your own environment — those run under your own Claude Code configuration and are your responsibility to audit.
+- Third-party tools or services invoked by skills (Claude API, GitHub API, etc.).
+- Vulnerabilities in Claude Code itself — report those to [Anthropic](https://www.anthropic.com/security).


### PR DESCRIPTION
## Summary

- Replace the GitHub default `SECURITY.md` template with a real security policy covering supported versions, reporting channel, response timeline, disclosure process, and scope.
- Reporting channel points to GitHub's private vulnerability reporting flow (already enabled on the repo) — no extra cost, no email address exposed.

## Ticket

[#34](https://github.com/psenger/ai-agent-skills/issues/34)

## Changes

- `SECURITY.md` — fully rewritten: v2.x supported-versions table, private advisory link, response timeline table, coordinated disclosure steps, in/out-of-scope statement
- `CHANGELOG.md` — Fixed entry added under `[Unreleased]`

## Test Plan

- [ ] Click "Report a vulnerability" on the repo Security tab — confirm it routes to the private advisory form
- [ ] Verify supported-versions table reflects the actual v2.x release line
- [ ] Confirm no email addresses or PII are present in the file

## Changelog

- **SECURITY** — Replace GitHub placeholder template with a real security policy: correct supported-versions table (v2.x), private vulnerability reporting via GitHub Security Advisories, response timeline, coordinated disclosure process, and scope statement. ([#34](https://github.com/psenger/ai-agent-skills/issues/34))